### PR TITLE
Add Claude Code Router adapter for OpenRouter Qwen

### DIFF
--- a/apps/api/app/api/chat/act.py
+++ b/apps/api/app/api/chat/act.py
@@ -160,7 +160,7 @@ async def execute_chat_task(
         )
         
         # Qwen Coder does not support images yet; drop them to prevent errors
-        safe_images = [] if cli_preference == CLIType.QWEN else images
+        safe_images = [] if cli_preference in (CLIType.QWEN, CLIType.ROUTER) else images
 
         result = await cli_manager.execute_instruction(
             instruction=instruction,

--- a/apps/api/app/api/settings.py
+++ b/apps/api/app/api/settings.py
@@ -84,12 +84,20 @@ async def get_cli_status() -> Dict[str, Any]:
     results = {}
     
     # 새로운 UnifiedCLIManager의 CLI 인스턴스 사용
-    from app.services.cli.unified_manager import ClaudeCodeCLI, CursorAgentCLI, CodexCLI, QwenCLI, GeminiCLI
+    from app.services.cli.unified_manager import (
+        ClaudeCodeCLI,
+        ClaudeCodeRouterCLI,
+        CursorAgentCLI,
+        CodexCLI,
+        QwenCLI,
+        GeminiCLI,
+    )
     cli_instances = {
         "claude": ClaudeCodeCLI(),
         "cursor": CursorAgentCLI(),
         "codex": CodexCLI(),
         "qwen": QwenCLI(),
+        "router": ClaudeCodeRouterCLI(),
         "gemini": GeminiCLI()
     }
     

--- a/apps/api/app/services/cli/adapters/__init__.py
+++ b/apps/api/app/services/cli/adapters/__init__.py
@@ -1,4 +1,5 @@
 from .claude_code import ClaudeCodeCLI
+from .claude_code_router import ClaudeCodeRouterCLI
 from .cursor_agent import CursorAgentCLI
 from .codex_cli import CodexCLI
 from .qwen_cli import QwenCLI
@@ -6,6 +7,7 @@ from .gemini_cli import GeminiCLI
 
 __all__ = [
     "ClaudeCodeCLI",
+    "ClaudeCodeRouterCLI",
     "CursorAgentCLI",
     "CodexCLI",
     "QwenCLI",

--- a/apps/api/app/services/cli/adapters/claude_code_router.py
+++ b/apps/api/app/services/cli/adapters/claude_code_router.py
@@ -1,0 +1,605 @@
+"""Claude Code Router adapter.
+
+This adapter talks to a running `claude-code-router` instance which in turn
+proxies requests to other model providers (e.g. OpenRouter's Qwen 3 Coder).
+It translates the Anthropic Messages streaming protocol into Claudable's
+Message objects and executes the common Claude Code tooling locally.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
+
+import httpx
+
+from app.core.terminal_ui import ui
+from app.models.messages import Message
+
+from ..base import BaseCLI, CLIType, get_display_path
+
+
+def _default_router_model() -> str:
+    return os.getenv("CLAUDE_CODE_ROUTER_MODEL", "openrouter,qwen/qwen3-coder")
+
+
+class ClaudeCodeRouterCLI(BaseCLI):
+    """HTTP adapter for claude-code-router."""
+
+    _conversation_cache: Dict[str, List[Dict[str, Any]]] = {}
+
+    def __init__(self, db_session=None):
+        super().__init__(CLIType.ROUTER)
+        self.db_session = db_session
+
+    # ------------------------------------------------------------------
+    # Adapter interface
+    async def check_availability(self) -> Dict[str, Any]:
+        base_url = self._get_base_url()
+        if not base_url:
+            return {
+                "available": False,
+                "configured": False,
+                "error": (
+                    "Set CLAUDE_CODE_ROUTER_URL to the running claude-code-router "
+                    "instance (e.g. http://127.0.0.1:3456)."
+                ),
+            }
+
+        url = base_url.rstrip("/") + "/health"
+        headers = self._build_headers()
+
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(url, headers=headers)
+            if response.status_code == 200:
+                return {
+                    "available": True,
+                    "configured": True,
+                    "mode": "HTTP",
+                    "base_url": base_url,
+                    "models": self.get_supported_models(),
+                    "default_models": [_default_router_model()],
+                }
+            return {
+                "available": False,
+                "configured": False,
+                "error": f"Router healthcheck failed: {response.status_code} {response.text[:200]}",
+            }
+        except httpx.HTTPError as exc:
+            return {
+                "available": False,
+                "configured": False,
+                "error": f"Unable to reach claude-code-router: {exc}",
+            }
+
+    async def execute_with_streaming(
+        self,
+        instruction: str,
+        project_path: str,
+        session_id: Optional[str] = None,
+        log_callback: Optional[Callable[[str], Any]] = None,
+        images: Optional[List[Dict[str, Any]]] = None,
+        model: Optional[str] = None,
+        is_initial_prompt: bool = False,
+    ) -> AsyncGenerator[Message, None]:
+        base_url = self._get_base_url()
+        if not base_url:
+            yield self._error_message(
+                project_path,
+                session_id,
+                "claude-code-router base URL not configured. Set CLAUDE_CODE_ROUTER_URL.",
+            )
+            return
+
+        if images:
+            ui.warning("Claude Code Router does not yet support image input; ignoring attachments.", "Router")
+
+        from app.services.claude_act import get_system_prompt
+
+        system_prompt = get_system_prompt()
+        cli_model = self._get_cli_model_name(model) or _default_router_model()
+
+        project_identifier = Path(project_path).name if project_path else "project"
+        active_session_id = (
+            session_id or await self.get_session_id(project_identifier) or uuid.uuid4().hex
+        )
+        history = list(self._conversation_cache.get(active_session_id, []))
+
+        final_instruction = instruction
+        if is_initial_prompt:
+            final_instruction = self._augment_initial_instruction(instruction, project_path)
+
+        history.append({
+            "role": "user",
+            "content": [{"type": "text", "text": final_instruction}],
+        })
+
+        metadata_user = f"project_{project_identifier}_session_{active_session_id}"
+
+        while True:
+            try:
+                content_blocks, usage = await self._stream_once(
+                    base_url,
+                    history,
+                    system_prompt,
+                    cli_model,
+                    metadata_user,
+                )
+            except Exception as exc:  # pragma: no cover - network failure path
+                ui.error(f"Router request failed: {exc}", "Router")
+                yield self._error_message(
+                    project_path,
+                    session_id,
+                    f"Router request failed: {exc}",
+                )
+                return
+
+            text_output = self._collect_text(content_blocks)
+            if text_output.strip():
+                yield Message(
+                    id=str(uuid.uuid4()),
+                    project_id=project_path,
+                    role="assistant",
+                    message_type="chat",
+                    content=text_output.strip(),
+                    metadata_json={
+                        "cli_type": self.cli_type.value,
+                        "model": cli_model,
+                        "usage": usage,
+                    },
+                    session_id=session_id,
+                    created_at=self._now(),
+                )
+
+            tool_blocks = [block for block in content_blocks if block.get("type") == "tool_use"]
+
+            for tool in tool_blocks:
+                summary = self._create_tool_summary(tool.get("name"), tool.get("input", {}))
+                yield Message(
+                    id=str(uuid.uuid4()),
+                    project_id=project_path,
+                    role="assistant",
+                    message_type="tool_use",
+                    content=summary,
+                    metadata_json={
+                        "cli_type": self.cli_type.value,
+                        "tool_name": tool.get("name"),
+                        "tool_input": tool.get("input"),
+                    },
+                    session_id=session_id,
+                    created_at=self._now(),
+                )
+
+            history.append(self._format_assistant_blocks(content_blocks))
+
+            if not tool_blocks:
+                break
+
+            for tool in tool_blocks:
+                result_text, is_error = await self._execute_tool(tool, project_path)
+                history.append({
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool.get("id"),
+                            "content": result_text,
+                            "is_error": is_error,
+                        }
+                    ],
+                })
+
+                if result_text:
+                    yield Message(
+                        id=str(uuid.uuid4()),
+                        project_id=project_path,
+                        role="assistant",
+                        message_type="tool_result",
+                        content=result_text[:4000],
+                        metadata_json={
+                            "cli_type": self.cli_type.value,
+                            "event_type": "tool_result",
+                            "tool_name": tool.get("name"),
+                            "tool_use_id": tool.get("id"),
+                            "is_error": is_error,
+                        },
+                        session_id=session_id,
+                        created_at=self._now(),
+                    )
+
+        self._conversation_cache[active_session_id] = history
+        await self.set_session_id(project_identifier, active_session_id)
+
+    async def get_session_id(self, project_id: str) -> Optional[str]:
+        if not self.db_session:
+            return None
+        try:
+            from app.models.projects import Project
+
+            project = self.db_session.query(Project).filter(Project.id == project_id).first()
+            if not project:
+                return None
+            settings = project.settings or {}
+            return settings.get("router_session_id")
+        except Exception as exc:  # pragma: no cover - DB failure path
+            ui.warning(f"Failed to load router session id: {exc}", "Router")
+            return None
+
+    async def set_session_id(self, project_id: str, session_id: str) -> None:
+        if not self.db_session:
+            return
+        try:
+            from app.models.projects import Project
+
+            project = self.db_session.query(Project).filter(Project.id == project_id).first()
+            if not project:
+                return
+            settings = project.settings or {}
+            settings["router_session_id"] = session_id
+            project.settings = settings
+            self.db_session.commit()
+        except Exception as exc:  # pragma: no cover - DB failure path
+            self.db_session.rollback()
+            ui.warning(f"Failed to persist router session id: {exc}", "Router")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _get_base_url(self) -> Optional[str]:
+        return os.getenv("CLAUDE_CODE_ROUTER_URL")
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {"content-type": "application/json"}
+        api_key = os.getenv("CLAUDE_CODE_ROUTER_API_KEY")
+        if api_key:
+            headers["x-api-key"] = api_key
+            headers.setdefault("authorization", f"Bearer {api_key}")
+        return headers
+
+    async def _stream_once(
+        self,
+        base_url: str,
+        history: List[Dict[str, Any]],
+        system_prompt: str,
+        model: str,
+        metadata_user: str,
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        payload = {
+            "model": model,
+            "messages": history,
+            "system": [{"type": "text", "text": system_prompt}],
+            "stream": True,
+            "metadata": {"user_id": metadata_user},
+        }
+
+        url = base_url.rstrip("/") + "/v1/messages"
+        headers = self._build_headers()
+
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with client.stream("POST", url, headers=headers, json=payload) as response:
+                if response.status_code >= 400:
+                    text = await response.aread()
+                    raise RuntimeError(
+                        f"Router error {response.status_code}: {text.decode(errors='ignore')[:500]}"
+                    )
+
+                block_states: Dict[int, Dict[str, Any]] = {}
+                usage: Dict[str, Any] = {}
+
+                async for event, data in self._iter_sse(response):
+                    if event == "content_block_start":
+                        index = data.get("index", 0)
+                        block = data.get("content_block", {}) or {}
+                        block_type = block.get("type")
+                        if block_type == "output_text":
+                            block_states[index] = {"type": "text", "text": ""}
+                        elif block_type == "tool_use":
+                            block_states[index] = {
+                                "type": "tool_use",
+                                "id": block.get("id"),
+                                "name": block.get("name"),
+                                "input_buffer": "",
+                            }
+                    elif event == "content_block_delta":
+                        index = data.get("index", 0)
+                        block = block_states.get(index)
+                        if not block:
+                            continue
+                        delta = data.get("delta", {})
+                        delta_type = delta.get("type")
+                        if block.get("type") == "text" and delta_type == "output_text_delta":
+                            block["text"] = block.get("text", "") + delta.get("text", "")
+                        elif block.get("type") == "tool_use" and delta_type == "input_json_delta":
+                            block["input_buffer"] = block.get("input_buffer", "") + delta.get("partial_json", "")
+                    elif event == "content_block_stop":
+                        index = data.get("index", 0)
+                        block = block_states.get(index)
+                        if not block:
+                            continue
+                        if block.get("type") == "tool_use":
+                            raw = block.pop("input_buffer", "")
+                            if raw:
+                                try:
+                                    block["input"] = json.loads(raw)
+                                except json.JSONDecodeError:
+                                    block["input"] = {"raw": raw}
+                            else:
+                                block["input"] = {}
+                    elif event == "message_delta":
+                        usage.update(data.get("usage", {}))
+                    elif event == "error":  # pragma: no cover - propagated error
+                        raise RuntimeError(data.get("error", "router stream error"))
+
+                content_blocks: List[Dict[str, Any]] = []
+                for index in sorted(block_states.keys()):
+                    block = block_states[index]
+                    if block.get("type") == "text":
+                        content_blocks.append({"type": "text", "text": block.get("text", "")})
+                    elif block.get("type") == "tool_use":
+                        content_blocks.append(
+                            {
+                                "type": "tool_use",
+                                "id": block.get("id"),
+                                "name": block.get("name"),
+                                "input": block.get("input", {}),
+                            }
+                        )
+
+                return content_blocks, usage
+
+    async def _iter_sse(self, response: httpx.Response):
+        event_name: Optional[str] = None
+        data_lines: List[str] = []
+
+        async for raw_line in response.aiter_lines():
+            if raw_line == "":
+                if event_name and data_lines:
+                    data = self._parse_sse_data("\n".join(data_lines))
+                    yield event_name, data
+                event_name = None
+                data_lines = []
+                continue
+
+            if raw_line.startswith(":"):
+                continue
+            if raw_line.startswith("event:"):
+                event_name = raw_line[len("event:") :].strip()
+            elif raw_line.startswith("data:"):
+                data_lines.append(raw_line[len("data:") :].strip())
+
+        if event_name and data_lines:
+            data = self._parse_sse_data("\n".join(data_lines))
+            yield event_name, data
+
+    def _parse_sse_data(self, payload: str) -> Dict[str, Any]:
+        try:
+            return json.loads(payload) if payload else {}
+        except json.JSONDecodeError:
+            return {"raw": payload}
+
+    def _collect_text(self, blocks: List[Dict[str, Any]]) -> str:
+        return "".join(block.get("text", "") for block in blocks if block.get("type") == "text")
+
+    def _format_assistant_blocks(self, blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
+        content: List[Dict[str, Any]] = []
+        for block in blocks:
+            if block.get("type") == "text":
+                content.append({"type": "text", "text": block.get("text", "")})
+            elif block.get("type") == "tool_use":
+                content.append(
+                    {
+                        "type": "tool_use",
+                        "id": block.get("id"),
+                        "name": block.get("name"),
+                        "input": block.get("input", {}),
+                    }
+                )
+        return {"role": "assistant", "content": content}
+
+    def _augment_initial_instruction(self, instruction: str, project_path: str) -> str:
+        try:
+            entries = []
+            for root, dirs, files in os.walk(project_path):
+                rel_root = os.path.relpath(root, project_path)
+                if rel_root == ".":
+                    rel_root = ""
+                for name in sorted(files):
+                    if name.startswith("."):
+                        continue
+                    full = os.path.join(rel_root, name) if rel_root else name
+                    entries.append(full)
+                if len(entries) > 200:
+                    break
+            structure = "\n".join(entries[:200])
+            return (
+                instruction
+                + "\n\n<initial_context>\n"
+                + structure
+                + "\n</initial_context>"
+            )
+        except Exception:
+            return instruction
+
+    async def _execute_tool(self, tool: Dict[str, Any], project_path: str) -> Tuple[str, bool]:
+        name = tool.get("name") or ""
+        tool_input = tool.get("input") or {}
+        normalized = self._normalize_tool_name(name)
+
+        try:
+            if normalized == "Read":
+                result = await self._tool_read(project_path, tool_input)
+                return result, False
+            if normalized in ("Write", "Edit"):
+                result = await self._tool_write(project_path, tool_input)
+                return result, False
+            if normalized == "LS":
+                result = await self._tool_ls(project_path, tool_input)
+                return result, False
+            if normalized == "Glob":
+                result = await self._tool_glob(project_path, tool_input)
+                return result, False
+            if normalized == "Grep":
+                result = await self._tool_grep(project_path, tool_input)
+                return result, False
+            if normalized == "Bash":
+                result = await self._tool_bash(project_path, tool_input)
+                return result, False
+        except Exception as exc:
+            return f"Error running tool {name}: {exc}", True
+
+        return f"Tool {name} is not supported yet.", True
+
+    async def _tool_read(self, project_path: str, params: Dict[str, Any]) -> str:
+        path = (
+            params.get("file_path")
+            or params.get("path")
+            or params.get("file")
+        )
+        if not path:
+            raise ValueError("read tool missing path")
+        abs_path = self._resolve_path(project_path, path)
+        if not os.path.exists(abs_path):
+            raise FileNotFoundError(path)
+        with open(abs_path, "r", encoding="utf-8", errors="ignore") as f:
+            content = f.read()
+        return content[:200000]
+
+    async def _tool_write(self, project_path: str, params: Dict[str, Any]) -> str:
+        path = (
+            params.get("file_path")
+            or params.get("path")
+            or params.get("file")
+        )
+        if not path:
+            raise ValueError("write tool missing path")
+        abs_path = self._resolve_path(project_path, path)
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+
+        content = (
+            params.get("content")
+            or params.get("text")
+            or params.get("code")
+            or params.get("new_content")
+        )
+        if content is None:
+            if params.get("old_content") and params.get("replacement"):
+                with open(abs_path, "r", encoding="utf-8", errors="ignore") as f:
+                    existing = f.read()
+                content = existing.replace(params["old_content"], params["replacement"])
+            else:
+                raise ValueError("write tool missing content")
+
+        with open(abs_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        return f"Wrote {len(content)} characters to {get_display_path(abs_path)}"
+
+    async def _tool_ls(self, project_path: str, params: Dict[str, Any]) -> str:
+        path = params.get("path") or params.get("directory") or "."
+        abs_path = self._resolve_path(project_path, path)
+        if not os.path.isdir(abs_path):
+            raise NotADirectoryError(path)
+        entries = sorted(os.listdir(abs_path))
+        display = [entry for entry in entries if not entry.startswith(".git")]
+        return "\n".join(display[:200])
+
+    async def _tool_glob(self, project_path: str, params: Dict[str, Any]) -> str:
+        import glob
+
+        pattern = params.get("pattern") or params.get("globPattern")
+        if not pattern:
+            raise ValueError("glob tool missing pattern")
+        full_pattern = os.path.join(project_path, pattern)
+        matches = [
+            get_display_path(match)
+            for match in glob.glob(full_pattern, recursive=True)
+        ]
+        return "\n".join(matches[:200]) if matches else "No matches found"
+
+    async def _tool_grep(self, project_path: str, params: Dict[str, Any]) -> str:
+        pattern = params.get("pattern") or params.get("query")
+        if not pattern:
+            raise ValueError("grep tool missing pattern")
+        path = params.get("path") or params.get("file")
+        results: List[str] = []
+        regex = re.compile(pattern)
+
+        if path:
+            abs_path = self._resolve_path(project_path, path)
+            if os.path.isdir(abs_path):
+                for root, _, files in os.walk(abs_path):
+                    for name in files:
+                        target = os.path.join(root, name)
+                        results.extend(self._grep_file(target, regex))
+            else:
+                results.extend(self._grep_file(abs_path, regex))
+        else:
+            for root, _, files in os.walk(project_path):
+                for name in files:
+                    target = os.path.join(root, name)
+                    results.extend(self._grep_file(target, regex))
+
+        if not results:
+            return "No matches found"
+        return "\n".join(results[:200])
+
+    def _grep_file(self, path: str, regex: re.Pattern[str]) -> List[str]:
+        matches: List[str] = []
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                for idx, line in enumerate(f, start=1):
+                    if regex.search(line):
+                        matches.append(f"{get_display_path(path)}:{idx}: {line.strip()}")
+        except Exception:
+            pass
+        return matches
+
+    async def _tool_bash(self, project_path: str, params: Dict[str, Any]) -> str:
+        command = params.get("command") or params.get("cmd")
+        if not command:
+            raise ValueError("bash tool missing command")
+
+        process = await asyncio.create_subprocess_shell(
+            command,
+            cwd=project_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+        output = ""
+        if stdout:
+            output += stdout.decode(errors="ignore")
+        if stderr:
+            output += "\n" + stderr.decode(errors="ignore")
+        return output.strip()[:8000] or f"Command exited with code {process.returncode}"
+
+    def _resolve_path(self, project_path: str, raw_path: str) -> str:
+        base = os.path.abspath(project_path or ".")
+        joined = os.path.abspath(os.path.join(base, raw_path))
+        if not joined.startswith(base):
+            raise ValueError("Path escapes project directory")
+        return joined
+
+    def _now(self):
+        from datetime import datetime
+
+        return datetime.utcnow()
+
+    def _error_message(self, project_path: str, session_id: Optional[str], content: str) -> Message:
+        return Message(
+            id=str(uuid.uuid4()),
+            project_id=project_path,
+            role="assistant",
+            message_type="error",
+            content=content,
+            metadata_json={"cli_type": self.cli_type.value},
+            session_id=session_id,
+            created_at=self._now(),
+        )
+
+
+__all__ = ["ClaudeCodeRouterCLI"]

--- a/apps/api/app/services/cli/base.py
+++ b/apps/api/app/services/cli/base.py
@@ -95,6 +95,15 @@ MODEL_MAPPING: Dict[str, Dict[str, str]] = {
         # Allow direct
         "qwen-coder": "qwen-coder",
     },
+    "router": {
+        # Default route targets claude-code-router configured with OpenRouter
+        "qwen3-coder-plus": os.getenv(
+            "CLAUDE_CODE_ROUTER_MODEL", "openrouter,qwen/qwen3-coder"
+        ),
+        "Qwen3 Coder Plus": os.getenv(
+            "CLAUDE_CODE_ROUTER_MODEL", "openrouter,qwen/qwen3-coder"
+        ),
+    },
     "gemini": {
         "gemini-2.5-pro": "gemini-2.5-pro",
         "gemini-2.5-flash": "gemini-2.5-flash",
@@ -109,6 +118,7 @@ class CLIType(str, Enum):
     CURSOR = "cursor"
     CODEX = "codex"
     QWEN = "qwen"
+    ROUTER = "router"
     GEMINI = "gemini"
 
 

--- a/apps/api/app/services/cli/manager.py
+++ b/apps/api/app/services/cli/manager.py
@@ -12,7 +12,14 @@ from app.core.websocket.manager import manager as ws_manager
 from app.models.messages import Message
 
 from .base import CLIType
-from .adapters import ClaudeCodeCLI, CursorAgentCLI, CodexCLI, QwenCLI, GeminiCLI
+from .adapters import (
+    ClaudeCodeCLI,
+    ClaudeCodeRouterCLI,
+    CursorAgentCLI,
+    CodexCLI,
+    QwenCLI,
+    GeminiCLI,
+)
 
 
 class UnifiedCLIManager:
@@ -38,6 +45,7 @@ class UnifiedCLIManager:
             CLIType.CURSOR: CursorAgentCLI(db_session=db),
             CLIType.CODEX: CodexCLI(db_session=db),
             CLIType.QWEN: QwenCLI(db_session=db),
+            CLIType.ROUTER: ClaudeCodeRouterCLI(db_session=db),
             CLIType.GEMINI: GeminiCLI(db_session=db),
         }
 

--- a/apps/api/app/services/cli/unified_manager.py
+++ b/apps/api/app/services/cli/unified_manager.py
@@ -9,7 +9,14 @@ Implementations live in:
 """
 
 from .base import BaseCLI, CLIType, MODEL_MAPPING, get_project_root, get_display_path
-from .adapters import ClaudeCodeCLI, CursorAgentCLI, CodexCLI, QwenCLI, GeminiCLI
+from .adapters import (
+    ClaudeCodeCLI,
+    ClaudeCodeRouterCLI,
+    CursorAgentCLI,
+    CodexCLI,
+    QwenCLI,
+    GeminiCLI,
+)
 from .manager import UnifiedCLIManager
 
 __all__ = [
@@ -19,6 +26,7 @@ __all__ = [
     "get_project_root",
     "get_display_path",
     "ClaudeCodeCLI",
+    "ClaudeCodeRouterCLI",
     "CursorAgentCLI",
     "CodexCLI",
     "QwenCLI",

--- a/apps/web/app/[project_id]/chat/page.tsx
+++ b/apps/web/app/[project_id]/chat/page.tsx
@@ -804,7 +804,7 @@ export default function ChatPage({ params }: Params) {
                 setSelectedModel('gpt-5');
               } else if (currentCli === 'codex') {
                 setSelectedModel('gpt-5');
-              } else if (currentCli === 'qwen') {
+              } else if (currentCli === 'qwen' || currentCli === 'router') {
                 setSelectedModel('qwen3-coder-plus');
               } else if (currentCli === 'gemini') {
                 setSelectedModel('gemini-2.5-pro');
@@ -1651,8 +1651,8 @@ export default function ChatPage({ params }: Params) {
                         {deploymentStatus === 'ready' && publishedUrl && (
                           <div className="mb-4 p-4 bg-green-50 dark:bg-green-900/20 rounded-lg border border-green-200 dark:border-green-800">
                             <p className="text-sm font-medium text-green-700 dark:text-green-400 mb-2">Currently published at:</p>
-                            <a 
-                              href={publishedUrl} 
+                            <a
+                              href={publishedUrl ?? undefined}
                               target="_blank" 
                               rel="noopener noreferrer" 
                               className="text-sm text-green-600 dark:text-green-300 font-mono hover:underline break-all"

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -130,7 +130,7 @@ export default function HomePage() {
       if (cli === 'claude') setSelectedModel('claude-sonnet-4');
       else if (cli === 'cursor') setSelectedModel('gpt-5');
       else if (cli === 'codex') setSelectedModel('gpt-5');
-      else if (cli === 'qwen') setSelectedModel('qwen3-coder-plus');
+      else if (cli === 'qwen' || cli === 'router') setSelectedModel('qwen3-coder-plus');
       else if (cli === 'gemini') setSelectedModel('gemini-2.5-pro');
     }
   }, [globalSettings, usingGlobalDefaults, isInitialLoad]);
@@ -684,7 +684,7 @@ export default function HomePage() {
       setSelectedModel('gpt-5');
     } else if (assistant === 'codex') {
       setSelectedModel('gpt-5');
-    } else if (assistant === 'qwen') {
+    } else if (assistant === 'qwen' || assistant === 'router') {
       setSelectedModel('qwen3-coder-plus');
     } else if (assistant === 'gemini') {
       setSelectedModel('gemini-2.5-pro');
@@ -705,7 +705,8 @@ export default function HomePage() {
     { id: 'codex', name: 'Codex CLI', icon: '/oai.png' },
     { id: 'cursor', name: 'Cursor Agent', icon: '/cursor.png' },
     { id: 'gemini', name: 'Gemini CLI', icon: '/gemini.png' },
-    { id: 'qwen', name: 'Qwen Coder', icon: '/qwen.png' }
+    { id: 'qwen', name: 'Qwen Coder', icon: '/qwen.png' },
+    { id: 'router', name: 'Claude Code Router', icon: '/qwen.png' }
   ];
 
   return (
@@ -891,7 +892,7 @@ export default function HomePage() {
                                 >
                                   {project.preferred_cli === 'claude' ? 'Claude' : 
                                    project.preferred_cli === 'cursor' ? 'Cursor' : 
-                                   project.preferred_cli === 'qwen' ? 'Qwen' : 
+                                   project.preferred_cli === 'qwen' ? 'Qwen' : project.preferred_cli === 'router' ? 'Router' :
                                    project.preferred_cli === 'gemini' ? 'Gemini' : 
                                    project.preferred_cli === 'codex' ? 'Codex' : 
                                    project.preferred_cli}
@@ -1052,10 +1053,10 @@ export default function HomePage() {
               <div className="flex gap-1 flex-wrap items-center">
                 {/* Image Upload Button */}
                 <div className="flex items-center gap-2">
-                  {selectedAssistant === 'cursor' || selectedAssistant === 'qwen' ? (
+                  {selectedAssistant === 'cursor' || selectedAssistant === 'qwen' || selectedAssistant === 'router' ? (
                     <div 
                       className="flex items-center justify-center w-8 h-8 text-gray-300 dark:text-gray-600 cursor-not-allowed opacity-50 rounded-full"
-                      title={selectedAssistant === 'qwen' ? "Qwen Coder doesn't support image input" : "Cursor CLI doesn't support image input"}
+                      title={selectedAssistant === 'qwen' || selectedAssistant === 'router' ? "Qwen Coder doesn't support image input" : "Cursor CLI doesn't support image input"}
                     >
                       <ImageIcon className="h-4 w-4" />
                     </div>
@@ -1089,13 +1090,13 @@ export default function HomePage() {
                   >
                     <div className="w-4 h-4 rounded overflow-hidden">
                       <img 
-                        src={selectedAssistant === 'claude' ? '/claude.png' : selectedAssistant === 'cursor' ? '/cursor.png' : selectedAssistant === 'qwen' ? '/qwen.png' : selectedAssistant === 'gemini' ? '/gemini.png' : '/oai.png'} 
-                        alt={selectedAssistant === 'claude' ? 'Claude' : selectedAssistant === 'cursor' ? 'Cursor' : selectedAssistant === 'qwen' ? 'Qwen' : selectedAssistant === 'gemini' ? 'Gemini' : 'Codex'}
+                        src={selectedAssistant === 'claude' ? '/claude.png' : selectedAssistant === 'cursor' ? '/cursor.png' : (selectedAssistant === 'qwen' || selectedAssistant === 'router') ? '/qwen.png' : selectedAssistant === 'gemini' ? '/gemini.png' : '/oai.png'}
+                        alt={selectedAssistant === 'claude' ? 'Claude' : selectedAssistant === 'cursor' ? 'Cursor' : selectedAssistant === 'qwen' ? 'Qwen' : selectedAssistant === 'router' ? 'Router' : selectedAssistant === 'gemini' ? 'Gemini' : 'Codex'}
                         className="w-full h-full object-contain"
                       />
                     </div>
                     <span className="hidden md:flex text-sm font-medium">
-                      {selectedAssistant === 'claude' ? 'Claude Code' : selectedAssistant === 'cursor' ? 'Cursor Agent' : selectedAssistant === 'qwen' ? 'Qwen Coder' : selectedAssistant === 'gemini' ? 'Gemini CLI' : 'Codex CLI'}
+                      {selectedAssistant === 'claude' ? 'Claude Code' : selectedAssistant === 'cursor' ? 'Cursor Agent' : selectedAssistant === 'qwen' ? 'Qwen Coder' : selectedAssistant === 'router' ? 'Claude Code Router' : selectedAssistant === 'gemini' ? 'Gemini CLI' : 'Codex CLI'}
                     </span>
                     <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 -960 960 960" className="shrink-0 h-3 w-3 rotate-90" fill="currentColor">
                       <path d="M530-481 353-658q-9-9-8.5-21t9.5-21 21.5-9 21.5 9l198 198q5 5 7 10t2 11-2 11-7 10L396-261q-9 9-21 8.5t-21-9.5-9-21.5 9-21.5z"/>
@@ -1155,7 +1156,7 @@ export default function HomePage() {
                           return 'Claude Sonnet 4';
                         } else if (selectedAssistant === 'codex' && selectedModel === 'gpt-5') {
                           return 'GPT-5';
-                        } else if (selectedAssistant === 'qwen' && selectedModel === 'qwen3-coder-plus') {
+                        } else if ((selectedAssistant === 'qwen' || selectedAssistant === 'router') && selectedModel === 'qwen3-coder-plus') {
                           return 'Qwen3 Coder Plus';
                         } else if (selectedAssistant === 'gemini' && selectedModel === 'gemini-2.5-pro') {
                           return 'Gemini 2.5 Pro';

--- a/apps/web/components/CreateProjectModal.tsx
+++ b/apps/web/components/CreateProjectModal.tsx
@@ -66,6 +66,19 @@ const CLI_OPTIONS: CLIOption[] = [
     enabled: false
   },
   {
+    id: 'router',
+    name: 'Claude Code Router',
+    icon: '🛣️',
+    description: 'Proxy Claude Code to OpenRouter models via claude-code-router',
+    color: 'from-indigo-500 to-purple-500',
+    downloadUrl: 'https://github.com/musistudio/claude-code-router',
+    installCommand: 'npm install -g @musistudio/claude-code-router',
+    models: [
+      { id: 'qwen3-coder-plus', name: 'Qwen3 Coder Plus', description: 'OpenRouter proxy for Qwen 3 coder', supportsImages: false }
+    ],
+    features: ['OpenRouter proxying', 'Bring your own API key', 'Drop-in replacement for Qwen CLI'],
+  },
+  {
     id: 'gemini',
     name: 'Gemini CLI',
     icon: '💎',

--- a/apps/web/components/GlobalSettings.tsx
+++ b/apps/web/components/GlobalSettings.tsx
@@ -74,6 +74,20 @@ const CLI_OPTIONS: CLIOption[] = [
     ]
   },
   {
+    id: 'router',
+    name: 'Claude Code Router',
+    icon: '/qwen.png',
+    description: 'Proxy claude-code-router to OpenRouter models',
+    color: 'from-indigo-500 to-purple-500',
+    brandColor: '#6366F1',
+    downloadUrl: 'https://github.com/musistudio/claude-code-router',
+    installCommand: 'npm install -g @musistudio/claude-code-router',
+    enabled: true,
+    models: [
+      { id: 'qwen3-coder-plus', name: 'Qwen3 Coder Plus' }
+    ]
+  },
+  {
     id: 'gemini',
     name: 'Gemini CLI',
     icon: '/gemini.png',
@@ -568,9 +582,9 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                             {cli.id === 'codex' && (
                               <img src="/oai.png" alt="Codex" className="w-8 h-8" />
                             )}
-                            {cli.id === 'qwen' && (
+                            {cli.id === 'qwen' || cli.id === 'router' ? (
                               <img src="/qwen.png" alt="Qwen" className="w-8 h-8" />
-                            )}
+                            ) : null}
                             {cli.id === 'gemini' && (
                               <img src="/gemini.png" alt="Gemini" className="w-8 h-8" />
                             )}
@@ -879,7 +893,7 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                     2
                   </span>
                   {selectedCLI.id === 'gemini' && 'Authenticate (OAuth or API Key)'}
-                  {selectedCLI.id === 'qwen' && 'Authenticate (Qwen OAuth or API Key)'}
+                  {(selectedCLI.id === 'qwen' || selectedCLI.id === 'router') && 'Authenticate (Qwen OAuth or API Key)'}
                   {selectedCLI.id === 'codex' && 'Start Codex and sign in'}
                   {selectedCLI.id === 'claude' && 'Start Claude and sign in'}
                   {selectedCLI.id === 'cursor' && 'Start Cursor CLI and sign in'}
@@ -889,7 +903,7 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                     {selectedCLI.id === 'claude' ? 'claude' :
                      selectedCLI.id === 'cursor' ? 'cursor-agent' :
                      selectedCLI.id === 'codex' ? 'codex' :
-                     selectedCLI.id === 'qwen' ? 'qwen' :
+                     selectedCLI.id === 'qwen' ? 'qwen' : selectedCLI.id === 'router' ? 'ccr' :
                      selectedCLI.id === 'gemini' ? 'gemini' : ''}
                   </code>
                   <button
@@ -900,7 +914,7 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                       const authCmd = selectedCLI.id === 'claude' ? 'claude' :
                                       selectedCLI.id === 'cursor' ? 'cursor-agent' :
                                       selectedCLI.id === 'codex' ? 'codex' :
-                                      selectedCLI.id === 'qwen' ? 'qwen' :
+                                      selectedCLI.id === 'qwen' ? 'qwen' : selectedCLI.id === 'router' ? 'ccr' :
                                       selectedCLI.id === 'gemini' ? 'gemini' : '';
                       if (authCmd) navigator.clipboard.writeText(authCmd);
                       showToast('Command copied to clipboard', 'success');
@@ -928,7 +942,7 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                     {selectedCLI.id === 'claude' ? 'claude --version' :
                      selectedCLI.id === 'cursor' ? 'cursor-agent --version' :
                      selectedCLI.id === 'codex' ? 'codex --version' :
-                     selectedCLI.id === 'qwen' ? 'qwen --version' :
+                     selectedCLI.id === 'qwen' ? 'qwen --version' : selectedCLI.id === 'router' ? 'ccr --version' :
                      selectedCLI.id === 'gemini' ? 'gemini --version' : ''}
                   </code>
                   <button
@@ -939,7 +953,7 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                       const versionCmd = selectedCLI.id === 'claude' ? 'claude --version' :
                                         selectedCLI.id === 'cursor' ? 'cursor-agent --version' :
                                         selectedCLI.id === 'codex' ? 'codex --version' :
-                                        selectedCLI.id === 'qwen' ? 'qwen --version' :
+                                        selectedCLI.id === 'qwen' ? 'qwen --version' : selectedCLI.id === 'router' ? 'ccr --version' :
                                         selectedCLI.id === 'gemini' ? 'gemini --version' : '';
                       if (versionCmd) navigator.clipboard.writeText(versionCmd);
                       showToast('Command copied to clipboard', 'success');

--- a/apps/web/components/ProjectSettings.tsx
+++ b/apps/web/components/ProjectSettings.tsx
@@ -66,6 +66,20 @@ const CLI_OPTIONS: CLIOption[] = [
     features: ['Agentic coding', '1M context window', 'Apache 2.0 license']
   },
   {
+    id: 'router',
+    name: 'Claude Code Router',
+    icon: '🛣️',
+    description: 'Use claude-code-router to reach OpenRouter models',
+    color: 'from-indigo-500 to-purple-500',
+    checkCommand: 'ccr --version',
+    downloadUrl: 'https://github.com/musistudio/claude-code-router',
+    installCommand: 'npm install -g @musistudio/claude-code-router',
+    models: [
+      { id: 'qwen3-coder-plus', name: 'Qwen3 Coder Plus', description: 'OpenRouter proxy for Qwen 3 coder' },
+    ],
+    features: ['Bring your own OpenRouter key', 'Drop-in CLI replacement', 'Streamed tool support']
+  },
+  {
     id: 'gemini',
     name: 'Gemini CLI',
     icon: '💎',
@@ -168,6 +182,7 @@ export default function ProjectSettings({ isOpen, onClose, projectId, projectNam
       claude: { model: 'claude-sonnet-4-20250514', enabled: true },
       cursor: { model: 'cursor-smart', enabled: true },
       qwen: { model: 'qwen3-coder-plus', enabled: true },
+      router: { model: 'qwen3-coder-plus', enabled: true },
       gemini: { model: 'gemini-2.5-pro', enabled: true },
       codex: { model: 'gpt-4-turbo', enabled: true },
     }
@@ -267,6 +282,7 @@ export default function ProjectSettings({ isOpen, onClose, projectId, projectNam
             claude: { model: 'claude-opus-4.1', enabled: true },
             cursor: { model: 'gpt-5', enabled: false },
             qwen: { model: 'qwen3-coder-480b-a35b', enabled: false },
+            router: { model: 'qwen3-coder-plus', enabled: false },
             gemini: { model: 'gemini-2.5-pro', enabled: false },
             codex: { model: 'gpt-5', enabled: false }
           }
@@ -282,6 +298,7 @@ export default function ProjectSettings({ isOpen, onClose, projectId, projectNam
           claude: { model: 'claude-opus-4.1', enabled: true },
           cursor: { model: 'gpt-5', enabled: false },
           qwen: { model: 'qwen3-coder-480b', enabled: false },
+          router: { model: 'qwen3-coder-plus', enabled: false },
           gemini: { model: 'gemini-2.5-pro', enabled: false },
           codex: { model: 'gpt-5', enabled: false }
         }

--- a/apps/web/components/chat/ChatInput.tsx
+++ b/apps/web/components/chat/ChatInput.tsx
@@ -92,7 +92,7 @@ export default function ChatInput({
 
   // Handle files (for both drag drop and file input)
   const handleFiles = async (files: FileList) => {
-    if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen') return;
+    if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen' || preferredCli === 'router') return;
     
     setIsUploading(true);
     
@@ -143,13 +143,13 @@ export default function ChatInput({
   };
 
   // Drag and drop handlers
-  const handleDragEnter = (e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen') {
-      setIsDragOver(true);
-    }
-  };
+    const handleDragEnter = (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen' && preferredCli !== 'router') {
+        setIsDragOver(true);
+      }
+    };
 
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
@@ -160,22 +160,22 @@ export default function ChatInput({
     }
   };
 
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen') {
-      e.dataTransfer.dropEffect = 'copy';
-    } else {
-      e.dataTransfer.dropEffect = 'none';
-    }
-  };
+    const handleDragOver = (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen' && preferredCli !== 'router') {
+        e.dataTransfer.dropEffect = 'copy';
+      } else {
+        e.dataTransfer.dropEffect = 'none';
+      }
+    };
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setIsDragOver(false);
 
-    if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen') return;
+    if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen' || preferredCli === 'router') return;
 
     const files = e.dataTransfer.files;
     if (files.length > 0) {
@@ -190,7 +190,7 @@ export default function ChatInput({
   // Handle clipboard paste for images
   useEffect(() => {
     const handlePaste = (e: ClipboardEvent) => {
-      if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen') return;
+      if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen' || preferredCli === 'router') return;
       
       const items = e.clipboardData?.items;
       if (!items) return;
@@ -295,7 +295,7 @@ export default function ChatInput({
         </div>
         
         {/* Drag overlay */}
-        {isDragOver && projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen' && (
+        {isDragOver && projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen' && preferredCli !== 'router' && (
           <div className="absolute inset-0 bg-blue-50/90 dark:bg-blue-900/30 rounded-3xl flex items-center justify-center z-10 border-2 border-dashed border-blue-500">
             <div className="text-center">
               <div className="text-2xl mb-2">📸</div>
@@ -313,10 +313,10 @@ export default function ChatInput({
           <div className="flex items-center gap-2">
             {/* Image Upload Button */}
             {projectId && (
-              (preferredCli === 'cursor' || preferredCli === 'qwen') ? (
-                <div 
+              (preferredCli === 'cursor' || preferredCli === 'qwen' || preferredCli === 'router') ? (
+                <div
                   className="flex items-center justify-center w-8 h-8 text-gray-300 dark:text-gray-600 cursor-not-allowed opacity-50 rounded-full"
-                  title={preferredCli === 'qwen' ? "Qwen Coder doesn't support image input" : "Cursor CLI doesn't support image input"}
+                  title={preferredCli === 'qwen' || preferredCli === 'router' ? "Qwen Coder doesn't support image input" : "Cursor CLI doesn't support image input"}
                 >
                   <Image className="h-4 w-4" />
                 </div>
@@ -343,19 +343,20 @@ export default function ChatInput({
             {preferredCli && (
               <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 rounded-full">
                 {/* Agent Icon */}
-                <img 
-                  src={preferredCli === 'claude' ? '/claude.png' : 
-                       preferredCli === 'cursor' ? '/cursor.png' : 
-                       preferredCli === 'qwen' ? '/qwen.png' :
+                <img
+                  src={preferredCli === 'claude' ? '/claude.png' :
+                       preferredCli === 'cursor' ? '/cursor.png' :
+                       preferredCli === 'qwen' || preferredCli === 'router' ? '/qwen.png' :
                        preferredCli === 'gemini' ? '/gemini.png' :
-                       '/oai.png'} 
+                       '/oai.png'}
                   alt={preferredCli}
                   className="w-4 h-4"
                 />
                 <span>
-                  {preferredCli === 'claude' ? 'Claude Code' : 
-                   preferredCli === 'cursor' ? 'Cursor Agent' : 
+                  {preferredCli === 'claude' ? 'Claude Code' :
+                   preferredCli === 'cursor' ? 'Cursor Agent' :
                    preferredCli === 'qwen' ? 'Qwen Coder' :
+                   preferredCli === 'router' ? 'Claude Code Router' :
                    preferredCli === 'gemini' ? 'Gemini CLI' :
                    'Codex CLI'}
                 </span>

--- a/apps/web/types/cli.ts
+++ b/apps/web/types/cli.ts
@@ -77,6 +77,18 @@ export const CLI_OPTIONS: CLIOption[] = [
     ]
   },
   {
+    id: 'router',
+    name: 'Claude Code Router',
+    description: 'Proxy claude-code-router to OpenRouter models',
+    icon: '/qwen.png',
+    available: true,
+    configured: false,
+    enabled: true,
+    models: [
+      { id: 'qwen3-coder-plus', name: 'Qwen3 Coder Plus' }
+    ]
+  },
+  {
     id: 'gemini',
     name: 'Gemini',
     description: 'Gemini CLI',

--- a/apps/web/types/project.ts
+++ b/apps/web/types/project.ts
@@ -30,4 +30,4 @@ export interface ProjectSettings {
   selected_model?: string;
 }
 
-export type CLIType = 'claude' | 'cursor' | 'qwen' | 'gemini' | 'codex';
+export type CLIType = 'claude' | 'cursor' | 'qwen' | 'router' | 'gemini' | 'codex';


### PR DESCRIPTION
## Summary
- add a Claude Code Router CLI adapter that streams through claude-code-router, handles tool execution, and persists sessions
- register the new router CLI type in the backend availability checks and skip image uploads for qwen/router
- surface the router assistant across project creation/settings UI, share install commands, and align UI messaging with the new option

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9d539cdf88332a3fa3bf2cf6236fd