### PR TITLE
Add Claude Code Router integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Claudable supports multiple AI coding agents, giving you the flexibility to choo
 - **Cursor CLI** - Powerful multi-model AI agent
 - **Gemini CLI** - Google's open-source AI agent
 - **Qwen Code** - Alibaba's open-source coding CLI
+- **Claude Code Router** - claude-code-router proxy targeting OpenRouter's Qwen 3 Coder
 
 ### Claude Code (Recommended)
 **[Claude Code](https://docs.anthropic.com/en/docs/claude-code/setup)** - Anthropic's advanced AI coding agent with Claude Opus 4.1
@@ -111,6 +112,19 @@ Claudable supports multiple AI coding agents, giving you the flexibility to choo
   npm install -g @qwen-code/qwen-code@latest
   qwen --version
   ```
+
+### Claude Code Router (OpenRouter)
+**[Claude Code Router](https://github.com/musistudio/claude-code-router)** - Lightweight HTTP proxy that exposes the Anthropic Messages API while forwarding requests to providers such as OpenRouter.
+- **Features**: Streams tool calls compatible with Claudable's Claude workflows, lets you reuse Claude's terminal + MCP tools with non-Anthropic models like **Qwen 3 Coder**
+- **Context**: Determined by the upstream model (OpenRouter's Qwen 3 Coder currently offers 200K tokens)
+- **Pricing**: Pay-as-you-go via the upstream provider (OpenRouter in this guide)
+- **Installation**:
+  ```bash
+  npm install -g @musistudio/claude-code-router
+  ccr --version
+  ```
+- **Configuration**: Map the router's default model to `openrouter,qwen/qwen3-coder` and export your `OPENROUTER_API_KEY`
+- **Integration guide**: See [guides/claude-code-router.md](guides/claude-code-router.md) for a step-by-step walkthrough, including Codespaces environment variables and troubleshooting tips.
 
 ## Technology Stack
 

--- a/apps/api/app/api/chat/act.py
+++ b/apps/api/app/api/chat/act.py
@@ -160,7 +160,7 @@ async def execute_chat_task(
         )
         
         # Qwen Coder does not support images yet; drop them to prevent errors
-        safe_images = [] if cli_preference == CLIType.QWEN else images
+        safe_images = [] if cli_preference in (CLIType.QWEN, CLIType.ROUTER) else images
 
         result = await cli_manager.execute_instruction(
             instruction=instruction,
@@ -325,7 +325,7 @@ async def execute_act_task(
         )
         
         # Qwen Coder does not support images yet; drop them to prevent errors
-        safe_images = [] if cli_preference == CLIType.QWEN else images
+        safe_images = [] if cli_preference in (CLIType.QWEN, CLIType.ROUTER) else images
 
         result = await cli_manager.execute_instruction(
             instruction=instruction,

--- a/apps/api/app/api/chat/cli_preferences.py
+++ b/apps/api/app/api/chat/cli_preferences.py
@@ -40,6 +40,7 @@ class AllCLIStatusResponse(BaseModel):
     codex: CLIStatusResponse
     qwen: CLIStatusResponse
     gemini: CLIStatusResponse
+    router: CLIStatusResponse
     preferred_cli: str
 
 
@@ -193,6 +194,7 @@ async def get_all_cli_status(project_id: str, db: Session = Depends(get_db)):
     codex_status = await manager.check_cli_status(CLIType.CODEX)
     qwen_status = await manager.check_cli_status(CLIType.QWEN)
     gemini_status = await manager.check_cli_status(CLIType.GEMINI)
+    router_status = await manager.check_cli_status(CLIType.ROUTER)
 
     return AllCLIStatusResponse(
         claude=to_resp("claude", claude_status),
@@ -200,5 +202,6 @@ async def get_all_cli_status(project_id: str, db: Session = Depends(get_db)):
         codex=to_resp("codex", codex_status),
         qwen=to_resp("qwen", qwen_status),
         gemini=to_resp("gemini", gemini_status),
+        router=to_resp("router", router_status),
         preferred_cli=preferred_cli,
     )

--- a/apps/api/app/api/settings.py
+++ b/apps/api/app/api/settings.py
@@ -13,13 +13,18 @@ router = APIRouter(prefix="/api/settings", tags=["settings"])
 CLI_OPTIONS = [
     {
         "id": "claude",
-        "name": "Claude Code", 
+        "name": "Claude Code",
         "check_command": ["claude", "--version"]
     },
     {
         "id": "cursor",
         "name": "Cursor Agent",
         "check_command": ["cursor-agent", "--version"]
+    },
+    {
+        "id": "router",
+        "name": "Claude Code Router",
+        "check_command": ["ccr", "--version"]
     },
 ]
 
@@ -84,13 +89,21 @@ async def get_cli_status() -> Dict[str, Any]:
     results = {}
     
     # 새로운 UnifiedCLIManager의 CLI 인스턴스 사용
-    from app.services.cli.unified_manager import ClaudeCodeCLI, CursorAgentCLI, CodexCLI, QwenCLI, GeminiCLI
+    from app.services.cli.unified_manager import (
+        ClaudeCodeCLI,
+        ClaudeCodeRouterCLI,
+        CursorAgentCLI,
+        CodexCLI,
+        QwenCLI,
+        GeminiCLI,
+    )
     cli_instances = {
         "claude": ClaudeCodeCLI(),
         "cursor": CursorAgentCLI(),
         "codex": CodexCLI(),
         "qwen": QwenCLI(),
-        "gemini": GeminiCLI()
+        "gemini": GeminiCLI(),
+        "router": ClaudeCodeRouterCLI(),
     }
     
     # 모든 CLI를 병렬로 확인

--- a/apps/api/app/services/cli/adapters/__init__.py
+++ b/apps/api/app/services/cli/adapters/__init__.py
@@ -3,6 +3,7 @@ from .cursor_agent import CursorAgentCLI
 from .codex_cli import CodexCLI
 from .qwen_cli import QwenCLI
 from .gemini_cli import GeminiCLI
+from .claude_code_router import ClaudeCodeRouterCLI
 
 __all__ = [
     "ClaudeCodeCLI",
@@ -10,4 +11,5 @@ __all__ = [
     "CodexCLI",
     "QwenCLI",
     "GeminiCLI",
+    "ClaudeCodeRouterCLI",
 ]

--- a/apps/api/app/services/cli/adapters/claude_code_router.py
+++ b/apps/api/app/services/cli/adapters/claude_code_router.py
@@ -1,0 +1,650 @@
+"""Claude Code Router adapter.
+
+This adapter talks to a running `claude-code-router` instance which in turn
+proxies requests to other model providers (e.g. OpenRouter's Qwen 3 Coder).
+It translates the Anthropic Messages streaming protocol into Claudable's
+Message objects and executes the common Claude Code tooling locally.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple
+
+import httpx
+
+from app.core.terminal_ui import ui
+from app.models.messages import Message
+
+from ..base import BaseCLI, CLIType, get_display_path
+
+
+def _default_router_model() -> str:
+    return os.getenv("CLAUDE_CODE_ROUTER_MODEL", "openrouter,qwen/qwen3-coder")
+
+
+class ClaudeCodeRouterCLI(BaseCLI):
+    """HTTP adapter for claude-code-router."""
+
+    _conversation_cache: Dict[str, List[Dict[str, Any]]] = {}
+
+    def __init__(self, db_session=None):
+        super().__init__(CLIType.ROUTER)
+        self.db_session = db_session
+
+    # ------------------------------------------------------------------
+    # Adapter interface
+    async def check_availability(self) -> Dict[str, Any]:
+        base_url = self._get_base_url()
+        if not base_url:
+            return {
+                "available": False,
+                "configured": False,
+                "error": (
+                    "Set CLAUDE_CODE_ROUTER_URL to the running claude-code-router "
+                    "instance (e.g. http://127.0.0.1:3456)."
+                ),
+            }
+
+        url = base_url.rstrip("/") + "/health"
+        headers = self._build_headers()
+
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                response = await client.get(url, headers=headers)
+            if response.status_code == 200:
+                return {
+                    "available": True,
+                    "configured": True,
+                    "mode": "HTTP",
+                    "base_url": base_url,
+                    "models": self.get_supported_models(),
+                    "default_models": [_default_router_model()],
+                }
+            return {
+                "available": False,
+                "configured": False,
+                "error": f"Router healthcheck failed: {response.status_code} {response.text[:200]}",
+            }
+        except httpx.HTTPError as exc:
+            return {
+                "available": False,
+                "configured": False,
+                "error": f"Unable to reach claude-code-router: {exc}",
+            }
+
+    async def execute_with_streaming(
+        self,
+        instruction: str,
+        project_path: str,
+        session_id: Optional[str] = None,
+        log_callback: Optional[Callable[[str], Any]] = None,
+        images: Optional[List[Dict[str, Any]]] = None,
+        model: Optional[str] = None,
+        is_initial_prompt: bool = False,
+    ) -> AsyncGenerator[Message, None]:
+        base_url = self._get_base_url()
+        if not base_url:
+            yield self._error_message(
+                project_path,
+                session_id,
+                "claude-code-router base URL not configured. Set CLAUDE_CODE_ROUTER_URL.",
+            )
+            return
+
+        if images:
+            ui.warning("Claude Code Router does not yet support image input; ignoring attachments.", "Router")
+
+        from app.services.claude_act import get_system_prompt
+
+        system_prompt = get_system_prompt()
+        cli_model = self._get_cli_model_name(model) or _default_router_model()
+
+        project_identifier = self._extract_project_id(project_path)
+        active_session_id: str
+        if session_id:
+            active_session_id = session_id
+        elif project_identifier:
+            active_session_id = await self.get_session_id(project_identifier) or uuid.uuid4().hex
+        else:
+            active_session_id = uuid.uuid4().hex
+        history = list(self._conversation_cache.get(active_session_id, []))
+
+        final_instruction = instruction
+        if is_initial_prompt:
+            final_instruction = self._augment_initial_instruction(instruction, project_path)
+
+        history.append({
+            "role": "user",
+            "content": [{"type": "text", "text": final_instruction}],
+        })
+
+        metadata_user = f"project_{project_identifier or 'project'}_session_{active_session_id}"
+
+        while True:
+            try:
+                content_blocks, usage = await self._stream_once(
+                    base_url,
+                    history,
+                    system_prompt,
+                    cli_model,
+                    metadata_user,
+                )
+            except Exception as exc:  # pragma: no cover - network failure path
+                ui.error(f"Router request failed: {exc}", "Router")
+                yield self._error_message(
+                    project_path,
+                    session_id,
+                    f"Router request failed: {exc}",
+                )
+                return
+
+            text_output = self._collect_text(content_blocks)
+            if text_output.strip():
+                yield Message(
+                    id=str(uuid.uuid4()),
+                    project_id=project_path,
+                    role="assistant",
+                    message_type="chat",
+                    content=text_output.strip(),
+                    metadata_json={
+                        "cli_type": self.cli_type.value,
+                        "model": cli_model,
+                        "usage": usage,
+                    },
+                    session_id=session_id,
+                    created_at=self._now(),
+                )
+
+            tool_blocks = [block for block in content_blocks if block.get("type") == "tool_use"]
+
+            for tool in tool_blocks:
+                summary = self._create_tool_summary(tool.get("name"), tool.get("input", {}))
+                yield Message(
+                    id=str(uuid.uuid4()),
+                    project_id=project_path,
+                    role="assistant",
+                    message_type="tool_use",
+                    content=summary,
+                    metadata_json={
+                        "cli_type": self.cli_type.value,
+                        "tool_name": tool.get("name"),
+                        "tool_input": tool.get("input"),
+                    },
+                    session_id=session_id,
+                    created_at=self._now(),
+                )
+
+            history.append(self._format_assistant_blocks(content_blocks))
+
+            if not tool_blocks:
+                break
+
+            for tool in tool_blocks:
+                result_text, is_error = await self._execute_tool(tool, project_path)
+                history.append({
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool.get("id"),
+                            "content": result_text,
+                            "is_error": is_error,
+                        }
+                    ],
+                })
+
+                if result_text:
+                    yield Message(
+                        id=str(uuid.uuid4()),
+                        project_id=project_path,
+                        role="assistant",
+                        message_type="tool_result",
+                        content=result_text[:4000],
+                        metadata_json={
+                            "cli_type": self.cli_type.value,
+                            "event_type": "tool_result",
+                            "tool_name": tool.get("name"),
+                            "tool_use_id": tool.get("id"),
+                            "is_error": is_error,
+                        },
+                        session_id=session_id,
+                        created_at=self._now(),
+                    )
+
+        self._conversation_cache[active_session_id] = history
+        if project_identifier:
+            await self.set_session_id(project_identifier, active_session_id)
+
+    async def get_session_id(self, project_id: str) -> Optional[str]:
+        if not self.db_session:
+            return None
+        try:
+            from app.models.projects import Project
+
+            project = self.db_session.query(Project).filter(Project.id == project_id).first()
+            if not project:
+                return None
+            settings = project.settings or {}
+            return settings.get("router_session_id")
+        except Exception as exc:  # pragma: no cover - DB failure path
+            ui.warning(f"Failed to load router session id: {exc}", "Router")
+            return None
+
+    async def set_session_id(self, project_id: str, session_id: str) -> None:
+        if not self.db_session:
+            return
+        try:
+            from app.models.projects import Project
+
+            project = self.db_session.query(Project).filter(Project.id == project_id).first()
+            if not project:
+                return
+            settings = project.settings or {}
+            settings["router_session_id"] = session_id
+            project.settings = settings
+            self.db_session.commit()
+        except Exception as exc:  # pragma: no cover - DB failure path
+            self.db_session.rollback()
+            ui.warning(f"Failed to persist router session id: {exc}", "Router")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _get_base_url(self) -> Optional[str]:
+        """Return the configured router base URL with sensible fallbacks.
+
+        We prefer ``CLAUDE_CODE_ROUTER_URL`` when provided. When it is missing
+        (common in new Codespaces), we fall back to the local loopback port or
+        the forwarded Codespaces hostname so health checks keep working without
+        extra configuration.
+        """
+
+        explicit_url = os.getenv("CLAUDE_CODE_ROUTER_URL")
+        if explicit_url:
+            return explicit_url
+
+        port = os.getenv("CLAUDE_CODE_ROUTER_PORT", "3456")
+
+        codespace = os.getenv("CODESPACE_NAME")
+        forwarding_domain = os.getenv("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN")
+        if codespace and forwarding_domain:
+            return f"https://{port}-{codespace}.{forwarding_domain}"
+
+        return f"http://127.0.0.1:{port}"
+
+    def _extract_project_id(self, project_path: str | None) -> Optional[str]:
+        if not project_path:
+            return None
+
+        try:
+            parts = Path(project_path).parts
+        except Exception:
+            return None
+
+        if "projects" in parts:
+            index = parts.index("projects")
+            if index + 1 < len(parts):
+                return parts[index + 1]
+
+        if parts:
+            if parts[-1] == "repo" and len(parts) >= 2:
+                return parts[-2]
+            return parts[-1]
+
+        return None
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {"content-type": "application/json"}
+        api_key = os.getenv("CLAUDE_CODE_ROUTER_API_KEY")
+        if api_key:
+            headers["x-api-key"] = api_key
+            headers.setdefault("authorization", f"Bearer {api_key}")
+        return headers
+
+    async def _stream_once(
+        self,
+        base_url: str,
+        history: List[Dict[str, Any]],
+        system_prompt: str,
+        model: str,
+        metadata_user: str,
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        payload = {
+            "model": model,
+            "messages": history,
+            "system": [{"type": "text", "text": system_prompt}],
+            "stream": True,
+            "metadata": {"user_id": metadata_user},
+        }
+
+        url = base_url.rstrip("/") + "/v1/messages"
+        headers = self._build_headers()
+
+        async with httpx.AsyncClient(timeout=None) as client:
+            async with client.stream("POST", url, headers=headers, json=payload) as response:
+                if response.status_code >= 400:
+                    text = await response.aread()
+                    raise RuntimeError(
+                        f"Router error {response.status_code}: {text.decode(errors='ignore')[:500]}"
+                    )
+
+                block_states: Dict[int, Dict[str, Any]] = {}
+                usage: Dict[str, Any] = {}
+
+                async for event, data in self._iter_sse(response):
+                    if event == "content_block_start":
+                        index = data.get("index", 0)
+                        block = data.get("content_block", {}) or {}
+                        block_type = block.get("type")
+                        if block_type == "output_text":
+                            block_states[index] = {"type": "text", "text": ""}
+                        elif block_type == "tool_use":
+                            block_states[index] = {
+                                "type": "tool_use",
+                                "id": block.get("id"),
+                                "name": block.get("name"),
+                                "input_buffer": "",
+                            }
+                    elif event == "content_block_delta":
+                        index = data.get("index", 0)
+                        block = block_states.get(index)
+                        if not block:
+                            continue
+                        delta = data.get("delta", {})
+                        delta_type = delta.get("type")
+                        if block.get("type") == "text" and delta_type == "output_text_delta":
+                            block["text"] = block.get("text", "") + delta.get("text", "")
+                        elif block.get("type") == "tool_use" and delta_type == "input_json_delta":
+                            block["input_buffer"] = block.get("input_buffer", "") + delta.get("partial_json", "")
+                    elif event == "content_block_stop":
+                        index = data.get("index", 0)
+                        block = block_states.get(index)
+                        if not block:
+                            continue
+                        if block.get("type") == "tool_use":
+                            raw = block.pop("input_buffer", "")
+                            if raw:
+                                try:
+                                    block["input"] = json.loads(raw)
+                                except json.JSONDecodeError:
+                                    block["input"] = {"raw": raw}
+                            else:
+                                block["input"] = {}
+                    elif event == "message_delta":
+                        usage.update(data.get("usage", {}))
+                    elif event == "error":  # pragma: no cover - propagated error
+                        raise RuntimeError(data.get("error", "router stream error"))
+
+                content_blocks: List[Dict[str, Any]] = []
+                for index in sorted(block_states.keys()):
+                    block = block_states[index]
+                    if block.get("type") == "text":
+                        content_blocks.append({"type": "text", "text": block.get("text", "")})
+                    elif block.get("type") == "tool_use":
+                        content_blocks.append(
+                            {
+                                "type": "tool_use",
+                                "id": block.get("id"),
+                                "name": block.get("name"),
+                                "input": block.get("input", {}),
+                            }
+                        )
+
+                return content_blocks, usage
+
+    async def _iter_sse(self, response: httpx.Response):
+        event_name: Optional[str] = None
+        data_lines: List[str] = []
+
+        async for raw_line in response.aiter_lines():
+            if raw_line == "":
+                if event_name and data_lines:
+                    data = self._parse_sse_data("\n".join(data_lines))
+                    yield event_name, data
+                event_name = None
+                data_lines = []
+                continue
+
+            if raw_line.startswith(":"):
+                continue
+            if raw_line.startswith("event:"):
+                event_name = raw_line[len("event:") :].strip()
+            elif raw_line.startswith("data:"):
+                data_lines.append(raw_line[len("data:") :].strip())
+
+        if event_name and data_lines:
+            data = self._parse_sse_data("\n".join(data_lines))
+            yield event_name, data
+
+    def _parse_sse_data(self, payload: str) -> Dict[str, Any]:
+        try:
+            return json.loads(payload) if payload else {}
+        except json.JSONDecodeError:
+            return {"raw": payload}
+
+    def _collect_text(self, blocks: List[Dict[str, Any]]) -> str:
+        return "".join(block.get("text", "") for block in blocks if block.get("type") == "text")
+
+    def _format_assistant_blocks(self, blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
+        content: List[Dict[str, Any]] = []
+        for block in blocks:
+            if block.get("type") == "text":
+                content.append({"type": "text", "text": block.get("text", "")})
+            elif block.get("type") == "tool_use":
+                content.append(
+                    {
+                        "type": "tool_use",
+                        "id": block.get("id"),
+                        "name": block.get("name"),
+                        "input": block.get("input", {}),
+                    }
+                )
+        return {"role": "assistant", "content": content}
+
+    def _augment_initial_instruction(self, instruction: str, project_path: str) -> str:
+        try:
+            entries = []
+            for root, dirs, files in os.walk(project_path):
+                rel_root = os.path.relpath(root, project_path)
+                if rel_root == ".":
+                    rel_root = ""
+                for name in sorted(files):
+                    if name.startswith("."):
+                        continue
+                    full = os.path.join(rel_root, name) if rel_root else name
+                    entries.append(full)
+                if len(entries) > 200:
+                    break
+            structure = "\n".join(entries[:200])
+            return (
+                instruction
+                + "\n\n<initial_context>\n"
+                + structure
+                + "\n</initial_context>"
+            )
+        except Exception:
+            return instruction
+
+    async def _execute_tool(self, tool: Dict[str, Any], project_path: str) -> Tuple[str, bool]:
+        name = tool.get("name") or ""
+        tool_input = tool.get("input") or {}
+        normalized = self._normalize_tool_name(name)
+
+        try:
+            if normalized == "Read":
+                result = await self._tool_read(project_path, tool_input)
+                return result, False
+            if normalized in ("Write", "Edit"):
+                result = await self._tool_write(project_path, tool_input)
+                return result, False
+            if normalized == "LS":
+                result = await self._tool_ls(project_path, tool_input)
+                return result, False
+            if normalized == "Glob":
+                result = await self._tool_glob(project_path, tool_input)
+                return result, False
+            if normalized == "Grep":
+                result = await self._tool_grep(project_path, tool_input)
+                return result, False
+            if normalized == "Bash":
+                result = await self._tool_bash(project_path, tool_input)
+                return result, False
+        except Exception as exc:
+            return f"Error running tool {name}: {exc}", True
+
+        return f"Tool {name} is not supported yet.", True
+
+    async def _tool_read(self, project_path: str, params: Dict[str, Any]) -> str:
+        path = (
+            params.get("file_path")
+            or params.get("path")
+            or params.get("file")
+        )
+        if not path:
+            raise ValueError("read tool missing path")
+        abs_path = self._resolve_path(project_path, path)
+        if not os.path.exists(abs_path):
+            raise FileNotFoundError(path)
+        with open(abs_path, "r", encoding="utf-8", errors="ignore") as f:
+            content = f.read()
+        return content[:200000]
+
+    async def _tool_write(self, project_path: str, params: Dict[str, Any]) -> str:
+        path = (
+            params.get("file_path")
+            or params.get("path")
+            or params.get("file")
+        )
+        if not path:
+            raise ValueError("write tool missing path")
+        abs_path = self._resolve_path(project_path, path)
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+
+        content = (
+            params.get("content")
+            or params.get("text")
+            or params.get("code")
+            or params.get("new_content")
+        )
+        if content is None:
+            if params.get("old_content") and params.get("replacement"):
+                with open(abs_path, "r", encoding="utf-8", errors="ignore") as f:
+                    existing = f.read()
+                content = existing.replace(params["old_content"], params["replacement"])
+            else:
+                raise ValueError("write tool missing content")
+
+        with open(abs_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+        return f"Wrote {len(content)} characters to {get_display_path(abs_path)}"
+
+    async def _tool_ls(self, project_path: str, params: Dict[str, Any]) -> str:
+        path = params.get("path") or params.get("directory") or "."
+        abs_path = self._resolve_path(project_path, path)
+        if not os.path.isdir(abs_path):
+            raise NotADirectoryError(path)
+        entries = sorted(os.listdir(abs_path))
+        display = [entry for entry in entries if not entry.startswith(".git")]
+        return "\n".join(display[:200])
+
+    async def _tool_glob(self, project_path: str, params: Dict[str, Any]) -> str:
+        import glob
+
+        pattern = params.get("pattern") or params.get("globPattern")
+        if not pattern:
+            raise ValueError("glob tool missing pattern")
+        full_pattern = os.path.join(project_path, pattern)
+        matches = [
+            get_display_path(match)
+            for match in glob.glob(full_pattern, recursive=True)
+        ]
+        return "\n".join(matches[:200]) if matches else "No matches found"
+
+    async def _tool_grep(self, project_path: str, params: Dict[str, Any]) -> str:
+        pattern = params.get("pattern") or params.get("query")
+        if not pattern:
+            raise ValueError("grep tool missing pattern")
+        path = params.get("path") or params.get("file")
+        results: List[str] = []
+        regex = re.compile(pattern)
+
+        if path:
+            abs_path = self._resolve_path(project_path, path)
+            if os.path.isdir(abs_path):
+                for root, _, files in os.walk(abs_path):
+                    for name in files:
+                        target = os.path.join(root, name)
+                        results.extend(self._grep_file(target, regex))
+            else:
+                results.extend(self._grep_file(abs_path, regex))
+        else:
+            for root, _, files in os.walk(project_path):
+                for name in files:
+                    target = os.path.join(root, name)
+                    results.extend(self._grep_file(target, regex))
+
+        if not results:
+            return "No matches found"
+        return "\n".join(results[:200])
+
+    def _grep_file(self, path: str, regex: re.Pattern[str]) -> List[str]:
+        matches: List[str] = []
+        try:
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                for idx, line in enumerate(f, start=1):
+                    if regex.search(line):
+                        matches.append(f"{get_display_path(path)}:{idx}: {line.strip()}")
+        except Exception:
+            pass
+        return matches
+
+    async def _tool_bash(self, project_path: str, params: Dict[str, Any]) -> str:
+        command = params.get("command") or params.get("cmd")
+        if not command:
+            raise ValueError("bash tool missing command")
+
+        process = await asyncio.create_subprocess_shell(
+            command,
+            cwd=project_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+        output = ""
+        if stdout:
+            output += stdout.decode(errors="ignore")
+        if stderr:
+            output += "\n" + stderr.decode(errors="ignore")
+        return output.strip()[:8000] or f"Command exited with code {process.returncode}"
+
+    def _resolve_path(self, project_path: str, raw_path: str) -> str:
+        base = os.path.abspath(project_path or ".")
+        joined = os.path.abspath(os.path.join(base, raw_path))
+        if not joined.startswith(base):
+            raise ValueError("Path escapes project directory")
+        return joined
+
+    def _now(self):
+        from datetime import datetime
+
+        return datetime.utcnow()
+
+    def _error_message(self, project_path: str, session_id: Optional[str], content: str) -> Message:
+        return Message(
+            id=str(uuid.uuid4()),
+            project_id=project_path,
+            role="assistant",
+            message_type="error",
+            content=content,
+            metadata_json={"cli_type": self.cli_type.value},
+            session_id=session_id,
+            created_at=self._now(),
+        )
+
+
+__all__ = ["ClaudeCodeRouterCLI"]

--- a/apps/api/app/services/cli/base.py
+++ b/apps/api/app/services/cli/base.py
@@ -95,6 +95,11 @@ MODEL_MAPPING: Dict[str, Dict[str, str]] = {
         # Allow direct
         "qwen-coder": "qwen-coder",
     },
+    "router": {
+        "qwen3-coder-plus": "openrouter,qwen/qwen3-coder",
+        "Qwen3 Coder Plus": "openrouter,qwen/qwen3-coder",
+        "openrouter,qwen/qwen3-coder": "openrouter,qwen/qwen3-coder",
+    },
     "gemini": {
         "gemini-2.5-pro": "gemini-2.5-pro",
         "gemini-2.5-flash": "gemini-2.5-flash",
@@ -110,6 +115,7 @@ class CLIType(str, Enum):
     CODEX = "codex"
     QWEN = "qwen"
     GEMINI = "gemini"
+    ROUTER = "router"
 
 
 class BaseCLI(ABC):

--- a/apps/api/app/services/cli/manager.py
+++ b/apps/api/app/services/cli/manager.py
@@ -12,7 +12,14 @@ from app.core.websocket.manager import manager as ws_manager
 from app.models.messages import Message
 
 from .base import CLIType
-from .adapters import ClaudeCodeCLI, CursorAgentCLI, CodexCLI, QwenCLI, GeminiCLI
+from .adapters import (
+    ClaudeCodeCLI,
+    ClaudeCodeRouterCLI,
+    CursorAgentCLI,
+    CodexCLI,
+    QwenCLI,
+    GeminiCLI,
+)
 
 
 class UnifiedCLIManager:
@@ -39,6 +46,7 @@ class UnifiedCLIManager:
             CLIType.CODEX: CodexCLI(db_session=db),
             CLIType.QWEN: QwenCLI(db_session=db),
             CLIType.GEMINI: GeminiCLI(db_session=db),
+            CLIType.ROUTER: ClaudeCodeRouterCLI(db_session=db),
         }
 
     async def execute_instruction(

--- a/apps/api/app/services/cli/unified_manager.py
+++ b/apps/api/app/services/cli/unified_manager.py
@@ -9,7 +9,14 @@ Implementations live in:
 """
 
 from .base import BaseCLI, CLIType, MODEL_MAPPING, get_project_root, get_display_path
-from .adapters import ClaudeCodeCLI, CursorAgentCLI, CodexCLI, QwenCLI, GeminiCLI
+from .adapters import (
+    ClaudeCodeCLI,
+    ClaudeCodeRouterCLI,
+    CursorAgentCLI,
+    CodexCLI,
+    QwenCLI,
+    GeminiCLI,
+)
 from .manager import UnifiedCLIManager
 
 __all__ = [
@@ -20,6 +27,7 @@ __all__ = [
     "get_display_path",
     "ClaudeCodeCLI",
     "CursorAgentCLI",
+    "ClaudeCodeRouterCLI",
     "CodexCLI",
     "QwenCLI",
     "GeminiCLI",

--- a/apps/web/app/[project_id]/chat/page.tsx
+++ b/apps/web/app/[project_id]/chat/page.tsx
@@ -22,6 +22,7 @@ const assistantBrandColors: { [key: string]: string } = {
   claude: '#DE7356',
   cursor: '#6B7280',
   qwen: '#A855F7',
+  router: '#6366F1',
   gemini: '#4285F4',
   codex: '#000000'
 };
@@ -804,7 +805,7 @@ export default function ChatPage({ params }: Params) {
                 setSelectedModel('gpt-5');
               } else if (currentCli === 'codex') {
                 setSelectedModel('gpt-5');
-              } else if (currentCli === 'qwen') {
+              } else if (currentCli === 'qwen' || currentCli === 'router') {
                 setSelectedModel('qwen3-coder-plus');
               } else if (currentCli === 'gemini') {
                 setSelectedModel('gemini-2.5-pro');
@@ -817,7 +818,17 @@ export default function ChatPage({ params }: Params) {
           if (response.ok) {
             const settings = await response.json();
             if (!hasCliSet) setPreferredCli(settings.preferred_cli || 'claude');
-            if (!hasModelSet) setSelectedModel(settings.preferred_cli === 'claude' ? 'claude-sonnet-4' : 'gpt-5');
+            if (!hasModelSet) {
+              if (settings.preferred_cli === 'claude') {
+                setSelectedModel('claude-sonnet-4');
+              } else if (settings.preferred_cli === 'qwen' || settings.preferred_cli === 'router') {
+                setSelectedModel('qwen3-coder-plus');
+              } else if (settings.preferred_cli === 'gemini') {
+                setSelectedModel('gemini-2.5-pro');
+              } else {
+                setSelectedModel('gpt-5');
+              }
+            }
           }
         }
       }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -37,6 +37,7 @@ const assistantBrandColors: { [key: string]: string } = {
   claude: '#DE7356',
   cursor: '#6B7280',
   qwen: '#A855F7',
+  router: '#6366F1',
   gemini: '#4285F4',
   codex: '#000000'
 };
@@ -73,6 +74,9 @@ export default function HomePage() {
       { id: 'gpt-5', name: 'GPT-5' }
     ],
     qwen: [
+      { id: 'qwen3-coder-plus', name: 'Qwen3 Coder Plus' }
+    ],
+    router: [
       { id: 'qwen3-coder-plus', name: 'Qwen3 Coder Plus' }
     ],
     gemini: [
@@ -130,7 +134,7 @@ export default function HomePage() {
       if (cli === 'claude') setSelectedModel('claude-sonnet-4');
       else if (cli === 'cursor') setSelectedModel('gpt-5');
       else if (cli === 'codex') setSelectedModel('gpt-5');
-      else if (cli === 'qwen') setSelectedModel('qwen3-coder-plus');
+      else if (cli === 'qwen' || cli === 'router') setSelectedModel('qwen3-coder-plus');
       else if (cli === 'gemini') setSelectedModel('gemini-2.5-pro');
     }
   }, [globalSettings, usingGlobalDefaults, isInitialLoad]);
@@ -390,7 +394,7 @@ export default function HomePage() {
 
   // Handle files (for both drag drop and file input)
   const handleFiles = async (files: FileList) => {
-    if (selectedAssistant === 'cursor') return;
+    if (selectedAssistant === 'cursor' || selectedAssistant === 'router') return;
     
     setIsUploading(true);
     
@@ -438,7 +442,7 @@ export default function HomePage() {
   const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (selectedAssistant !== 'cursor') {
+    if (selectedAssistant !== 'cursor' && selectedAssistant !== 'router') {
       setIsDragOver(true);
     }
   };
@@ -455,7 +459,7 @@ export default function HomePage() {
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (selectedAssistant !== 'cursor') {
+    if (selectedAssistant !== 'cursor' && selectedAssistant !== 'router') {
       e.dataTransfer.dropEffect = 'copy';
     } else {
       e.dataTransfer.dropEffect = 'none';
@@ -467,7 +471,7 @@ export default function HomePage() {
     e.stopPropagation();
     setIsDragOver(false);
 
-    if (selectedAssistant === 'cursor') return;
+    if (selectedAssistant === 'cursor' || selectedAssistant === 'router') return;
 
     const files = e.dataTransfer.files;
     if (files.length > 0) {
@@ -684,7 +688,7 @@ export default function HomePage() {
       setSelectedModel('gpt-5');
     } else if (assistant === 'codex') {
       setSelectedModel('gpt-5');
-    } else if (assistant === 'qwen') {
+    } else if (assistant === 'qwen' || assistant === 'router') {
       setSelectedModel('qwen3-coder-plus');
     } else if (assistant === 'gemini') {
       setSelectedModel('gemini-2.5-pro');
@@ -705,7 +709,8 @@ export default function HomePage() {
     { id: 'codex', name: 'Codex CLI', icon: '/oai.png' },
     { id: 'cursor', name: 'Cursor Agent', icon: '/cursor.png' },
     { id: 'gemini', name: 'Gemini CLI', icon: '/gemini.png' },
-    { id: 'qwen', name: 'Qwen Coder', icon: '/qwen.png' }
+    { id: 'qwen', name: 'Qwen Coder', icon: '/qwen.png' },
+    { id: 'router', name: 'Claude Code Router', icon: '/qwen.png' }
   ];
 
   return (
@@ -889,11 +894,12 @@ export default function HomePage() {
                                     color: assistantBrandColors[project.preferred_cli] ? `${assistantBrandColors[project.preferred_cli]}CC` : '#6B7280'
                                   }}
                                 >
-                                  {project.preferred_cli === 'claude' ? 'Claude' : 
-                                   project.preferred_cli === 'cursor' ? 'Cursor' : 
-                                   project.preferred_cli === 'qwen' ? 'Qwen' : 
-                                   project.preferred_cli === 'gemini' ? 'Gemini' : 
-                                   project.preferred_cli === 'codex' ? 'Codex' : 
+                                  {project.preferred_cli === 'claude' ? 'Claude' :
+                                   project.preferred_cli === 'cursor' ? 'Cursor' :
+                                   project.preferred_cli === 'qwen' ? 'Qwen' :
+                                   project.preferred_cli === 'router' ? 'Claude Code Router' :
+                                   project.preferred_cli === 'gemini' ? 'Gemini' :
+                                   project.preferred_cli === 'codex' ? 'Codex' :
                                    project.preferred_cli}
                                 </span>
                               </div>
@@ -1035,7 +1041,7 @@ export default function HomePage() {
               </div>
               
               {/* Drag overlay */}
-              {isDragOver && selectedAssistant !== 'cursor' && (
+              {isDragOver && selectedAssistant !== 'cursor' && selectedAssistant !== 'router' && (
                 <div className="absolute inset-0 bg-[#DE7356]/10 dark:bg-[#DE7356]/20 rounded-[28px] flex items-center justify-center z-10 border-2 border-dashed border-[#DE7356]">
                   <div className="text-center">
                     <div className="text-3xl mb-3">📸</div>
@@ -1052,10 +1058,14 @@ export default function HomePage() {
               <div className="flex gap-1 flex-wrap items-center">
                 {/* Image Upload Button */}
                 <div className="flex items-center gap-2">
-                  {selectedAssistant === 'cursor' || selectedAssistant === 'qwen' ? (
-                    <div 
+                  {selectedAssistant === 'cursor' || selectedAssistant === 'qwen' || selectedAssistant === 'router' ? (
+                    <div
                       className="flex items-center justify-center w-8 h-8 text-gray-300 dark:text-gray-600 cursor-not-allowed opacity-50 rounded-full"
-                      title={selectedAssistant === 'qwen' ? "Qwen Coder doesn't support image input" : "Cursor CLI doesn't support image input"}
+                      title={selectedAssistant === 'qwen'
+                        ? "Qwen Coder doesn't support image input"
+                        : selectedAssistant === 'router'
+                          ? 'Claude Code Router currently forwards text-only prompts'
+                          : "Cursor CLI doesn't support image input"}
                     >
                       <ImageIcon className="h-4 w-4" />
                     </div>
@@ -1088,14 +1098,42 @@ export default function HomePage() {
                     className="justify-center whitespace-nowrap text-sm font-medium transition-colors duration-100 ease-in-out focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 border border-gray-200/50 dark:border-white/5 bg-transparent shadow-sm hover:bg-gray-50 dark:hover:bg-white/5 hover:border-gray-300/50 dark:hover:border-white/10 px-3 py-2 flex h-8 items-center gap-1 rounded-full text-gray-700 dark:text-white/80 hover:text-gray-900 dark:hover:text-white focus-visible:ring-0"
                   >
                     <div className="w-4 h-4 rounded overflow-hidden">
-                      <img 
-                        src={selectedAssistant === 'claude' ? '/claude.png' : selectedAssistant === 'cursor' ? '/cursor.png' : selectedAssistant === 'qwen' ? '/qwen.png' : selectedAssistant === 'gemini' ? '/gemini.png' : '/oai.png'} 
-                        alt={selectedAssistant === 'claude' ? 'Claude' : selectedAssistant === 'cursor' ? 'Cursor' : selectedAssistant === 'qwen' ? 'Qwen' : selectedAssistant === 'gemini' ? 'Gemini' : 'Codex'}
+                      <img
+                        src={selectedAssistant === 'claude'
+                          ? '/claude.png'
+                          : selectedAssistant === 'cursor'
+                            ? '/cursor.png'
+                            : selectedAssistant === 'qwen' || selectedAssistant === 'router'
+                              ? '/qwen.png'
+                              : selectedAssistant === 'gemini'
+                                ? '/gemini.png'
+                                : '/oai.png'}
+                        alt={selectedAssistant === 'claude'
+                          ? 'Claude'
+                          : selectedAssistant === 'cursor'
+                            ? 'Cursor'
+                            : selectedAssistant === 'qwen'
+                              ? 'Qwen'
+                              : selectedAssistant === 'router'
+                                ? 'Claude Code Router'
+                                : selectedAssistant === 'gemini'
+                                  ? 'Gemini'
+                                  : 'Codex'}
                         className="w-full h-full object-contain"
                       />
                     </div>
                     <span className="hidden md:flex text-sm font-medium">
-                      {selectedAssistant === 'claude' ? 'Claude Code' : selectedAssistant === 'cursor' ? 'Cursor Agent' : selectedAssistant === 'qwen' ? 'Qwen Coder' : selectedAssistant === 'gemini' ? 'Gemini CLI' : 'Codex CLI'}
+                      {selectedAssistant === 'claude'
+                        ? 'Claude Code'
+                        : selectedAssistant === 'cursor'
+                          ? 'Cursor Agent'
+                          : selectedAssistant === 'qwen'
+                            ? 'Qwen Coder'
+                            : selectedAssistant === 'router'
+                              ? 'Claude Code Router'
+                              : selectedAssistant === 'gemini'
+                                ? 'Gemini CLI'
+                                : 'Codex CLI'}
                     </span>
                     <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 -960 960 960" className="shrink-0 h-3 w-3 rotate-90" fill="currentColor">
                       <path d="M530-481 353-658q-9-9-8.5-21t9.5-21 21.5-9 21.5 9l198 198q5 5 7 10t2 11-2 11-7 10L396-261q-9 9-21 8.5t-21-9.5-9-21.5 9-21.5z"/>
@@ -1155,7 +1193,7 @@ export default function HomePage() {
                           return 'Claude Sonnet 4';
                         } else if (selectedAssistant === 'codex' && selectedModel === 'gpt-5') {
                           return 'GPT-5';
-                        } else if (selectedAssistant === 'qwen' && selectedModel === 'qwen3-coder-plus') {
+                        } else if ((selectedAssistant === 'qwen' || selectedAssistant === 'router') && selectedModel === 'qwen3-coder-plus') {
                           return 'Qwen3 Coder Plus';
                         } else if (selectedAssistant === 'gemini' && selectedModel === 'gemini-2.5-pro') {
                           return 'Gemini 2.5 Pro';

--- a/apps/web/components/CreateProjectModal.tsx
+++ b/apps/web/components/CreateProjectModal.tsx
@@ -66,6 +66,20 @@ const CLI_OPTIONS: CLIOption[] = [
     enabled: false
   },
   {
+    id: 'router',
+    name: 'Claude Code Router',
+    icon: '🛰️',
+    description: 'Proxy Claude Code through claude-code-router',
+    color: 'from-indigo-500 to-purple-500',
+    downloadUrl: 'https://github.com/musistudio/claude-code-router',
+    installCommand: 'npm install -g @musistudio/claude-code-router',
+    models: [
+      { id: 'qwen3-coder-plus', name: 'Qwen3 Coder Plus', description: 'OpenRouter Qwen 3 Coder via claude-code-router', supportsImages: false },
+    ],
+    features: ['Works with Claude Code tooling', 'HTTP router proxy', 'OpenRouter integration'],
+    enabled: true
+  },
+  {
     id: 'gemini',
     name: 'Gemini CLI',
     icon: '💎',

--- a/apps/web/components/GlobalSettings.tsx
+++ b/apps/web/components/GlobalSettings.tsx
@@ -74,6 +74,20 @@ const CLI_OPTIONS: CLIOption[] = [
     ]
   },
   {
+    id: 'router',
+    name: 'Claude Code Router',
+    icon: '/qwen.png',
+    description: 'Proxy claude-code-router to OpenRouter models',
+    color: 'from-indigo-500 to-purple-500',
+    brandColor: '#6366F1',
+    downloadUrl: 'https://github.com/musistudio/claude-code-router',
+    installCommand: 'npm install -g @musistudio/claude-code-router',
+    enabled: true,
+    models: [
+      { id: 'qwen3-coder-plus', name: 'Qwen3 Coder Plus' }
+    ]
+  },
+  {
     id: 'gemini',
     name: 'Gemini CLI',
     icon: '/gemini.png',
@@ -568,7 +582,7 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                             {cli.id === 'codex' && (
                               <img src="/oai.png" alt="Codex" className="w-8 h-8" />
                             )}
-                            {cli.id === 'qwen' && (
+                            {(cli.id === 'qwen' || cli.id === 'router') && (
                               <img src="/qwen.png" alt="Qwen" className="w-8 h-8" />
                             )}
                             {cli.id === 'gemini' && (
@@ -880,6 +894,7 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                   </span>
                   {selectedCLI.id === 'gemini' && 'Authenticate (OAuth or API Key)'}
                   {selectedCLI.id === 'qwen' && 'Authenticate (Qwen OAuth or API Key)'}
+                  {selectedCLI.id === 'router' && 'Configure Router URL and API Key'}
                   {selectedCLI.id === 'codex' && 'Start Codex and sign in'}
                   {selectedCLI.id === 'claude' && 'Start Claude and sign in'}
                   {selectedCLI.id === 'cursor' && 'Start Cursor CLI and sign in'}
@@ -890,6 +905,7 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                      selectedCLI.id === 'cursor' ? 'cursor-agent' :
                      selectedCLI.id === 'codex' ? 'codex' :
                      selectedCLI.id === 'qwen' ? 'qwen' :
+                     selectedCLI.id === 'router' ? 'ccr' :
                      selectedCLI.id === 'gemini' ? 'gemini' : ''}
                   </code>
                   <button
@@ -901,6 +917,7 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                                       selectedCLI.id === 'cursor' ? 'cursor-agent' :
                                       selectedCLI.id === 'codex' ? 'codex' :
                                       selectedCLI.id === 'qwen' ? 'qwen' :
+                                      selectedCLI.id === 'router' ? 'ccr' :
                                       selectedCLI.id === 'gemini' ? 'gemini' : '';
                       if (authCmd) navigator.clipboard.writeText(authCmd);
                       showToast('Command copied to clipboard', 'success');
@@ -929,6 +946,7 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                      selectedCLI.id === 'cursor' ? 'cursor-agent --version' :
                      selectedCLI.id === 'codex' ? 'codex --version' :
                      selectedCLI.id === 'qwen' ? 'qwen --version' :
+                     selectedCLI.id === 'router' ? 'ccr --version' :
                      selectedCLI.id === 'gemini' ? 'gemini --version' : ''}
                   </code>
                   <button
@@ -940,6 +958,7 @@ export default function GlobalSettings({ isOpen, onClose, initialTab = 'general'
                                         selectedCLI.id === 'cursor' ? 'cursor-agent --version' :
                                         selectedCLI.id === 'codex' ? 'codex --version' :
                                         selectedCLI.id === 'qwen' ? 'qwen --version' :
+                                        selectedCLI.id === 'router' ? 'ccr --version' :
                                         selectedCLI.id === 'gemini' ? 'gemini --version' : '';
                       if (versionCmd) navigator.clipboard.writeText(versionCmd);
                       showToast('Command copied to clipboard', 'success');

--- a/apps/web/components/ProjectSettings.tsx
+++ b/apps/web/components/ProjectSettings.tsx
@@ -66,6 +66,20 @@ const CLI_OPTIONS: CLIOption[] = [
     features: ['Agentic coding', '1M context window', 'Apache 2.0 license']
   },
   {
+    id: 'router',
+    name: 'Claude Code Router',
+    icon: '🛰️',
+    description: 'Route Claude Code to OpenRouter models',
+    color: 'from-indigo-500 to-purple-500',
+    checkCommand: 'ccr --version',
+    downloadUrl: 'https://github.com/musistudio/claude-code-router',
+    installCommand: 'npm install -g @musistudio/claude-code-router',
+    models: [
+      { id: 'qwen3-coder-plus', name: 'Qwen3 Coder Plus', description: 'OpenRouter Qwen 3 Coder via claude-code-router' },
+    ],
+    features: ['HTTP proxy for Claude Code', 'OpenRouter integration', 'Local tool execution']
+  },
+  {
     id: 'gemini',
     name: 'Gemini CLI',
     icon: '💎',
@@ -168,6 +182,7 @@ export default function ProjectSettings({ isOpen, onClose, projectId, projectNam
       claude: { model: 'claude-sonnet-4-20250514', enabled: true },
       cursor: { model: 'cursor-smart', enabled: true },
       qwen: { model: 'qwen3-coder-plus', enabled: true },
+      router: { model: 'qwen3-coder-plus', enabled: true },
       gemini: { model: 'gemini-2.5-pro', enabled: true },
       codex: { model: 'gpt-4-turbo', enabled: true },
     }

--- a/apps/web/components/chat/ChatInput.tsx
+++ b/apps/web/components/chat/ChatInput.tsx
@@ -92,7 +92,7 @@ export default function ChatInput({
 
   // Handle files (for both drag drop and file input)
   const handleFiles = async (files: FileList) => {
-    if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen') return;
+    if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen' || preferredCli === 'router') return;
     
     setIsUploading(true);
     
@@ -146,7 +146,7 @@ export default function ChatInput({
   const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen') {
+    if (projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen' && preferredCli !== 'router') {
       setIsDragOver(true);
     }
   };
@@ -163,7 +163,7 @@ export default function ChatInput({
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen') {
+    if (projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen' && preferredCli !== 'router') {
       e.dataTransfer.dropEffect = 'copy';
     } else {
       e.dataTransfer.dropEffect = 'none';
@@ -175,7 +175,7 @@ export default function ChatInput({
     e.stopPropagation();
     setIsDragOver(false);
 
-    if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen') return;
+    if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen' || preferredCli === 'router') return;
 
     const files = e.dataTransfer.files;
     if (files.length > 0) {
@@ -190,7 +190,7 @@ export default function ChatInput({
   // Handle clipboard paste for images
   useEffect(() => {
     const handlePaste = (e: ClipboardEvent) => {
-      if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen') return;
+      if (!projectId || preferredCli === 'cursor' || preferredCli === 'qwen' || preferredCli === 'router') return;
       
       const items = e.clipboardData?.items;
       if (!items) return;
@@ -295,7 +295,7 @@ export default function ChatInput({
         </div>
         
         {/* Drag overlay */}
-        {isDragOver && projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen' && (
+        {isDragOver && projectId && preferredCli !== 'cursor' && preferredCli !== 'qwen' && preferredCli !== 'router' && (
           <div className="absolute inset-0 bg-blue-50/90 dark:bg-blue-900/30 rounded-3xl flex items-center justify-center z-10 border-2 border-dashed border-blue-500">
             <div className="text-center">
               <div className="text-2xl mb-2">📸</div>
@@ -313,10 +313,14 @@ export default function ChatInput({
           <div className="flex items-center gap-2">
             {/* Image Upload Button */}
             {projectId && (
-              (preferredCli === 'cursor' || preferredCli === 'qwen') ? (
-                <div 
+              (preferredCli === 'cursor' || preferredCli === 'qwen' || preferredCli === 'router') ? (
+                <div
                   className="flex items-center justify-center w-8 h-8 text-gray-300 dark:text-gray-600 cursor-not-allowed opacity-50 rounded-full"
-                  title={preferredCli === 'qwen' ? "Qwen Coder doesn't support image input" : "Cursor CLI doesn't support image input"}
+                  title={preferredCli === 'qwen'
+                    ? "Qwen Coder doesn't support image input"
+                    : preferredCli === 'router'
+                      ? 'Claude Code Router currently forwards text-only prompts'
+                      : "Cursor CLI doesn't support image input"}
                 >
                   <Image className="h-4 w-4" />
                 </div>
@@ -344,18 +348,19 @@ export default function ChatInput({
               <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-800/50 rounded-full">
                 {/* Agent Icon */}
                 <img 
-                  src={preferredCli === 'claude' ? '/claude.png' : 
-                       preferredCli === 'cursor' ? '/cursor.png' : 
-                       preferredCli === 'qwen' ? '/qwen.png' :
+                  src={preferredCli === 'claude' ? '/claude.png' :
+                       preferredCli === 'cursor' ? '/cursor.png' :
+                       (preferredCli === 'qwen' || preferredCli === 'router') ? '/qwen.png' :
                        preferredCli === 'gemini' ? '/gemini.png' :
-                       '/oai.png'} 
+                       '/oai.png'}
                   alt={preferredCli}
                   className="w-4 h-4"
                 />
                 <span>
-                  {preferredCli === 'claude' ? 'Claude Code' : 
-                   preferredCli === 'cursor' ? 'Cursor Agent' : 
+                  {preferredCli === 'claude' ? 'Claude Code' :
+                   preferredCli === 'cursor' ? 'Cursor Agent' :
                    preferredCli === 'qwen' ? 'Qwen Coder' :
+                   preferredCli === 'router' ? 'Claude Code Router' :
                    preferredCli === 'gemini' ? 'Gemini CLI' :
                    'Codex CLI'}
                 </span>

--- a/apps/web/types/cli.ts
+++ b/apps/web/types/cli.ts
@@ -77,6 +77,18 @@ export const CLI_OPTIONS: CLIOption[] = [
     ]
   },
   {
+    id: 'router',
+    name: 'Claude Code Router',
+    description: 'Proxy claude-code-router to OpenRouter models',
+    icon: '/qwen.png',
+    available: true,
+    configured: false,
+    enabled: true,
+    models: [
+      { id: 'qwen3-coder-plus', name: 'Qwen3 Coder Plus' }
+    ]
+  },
+  {
     id: 'gemini',
     name: 'Gemini',
     description: 'Gemini CLI',

--- a/apps/web/types/project.ts
+++ b/apps/web/types/project.ts
@@ -30,4 +30,4 @@ export interface ProjectSettings {
   selected_model?: string;
 }
 
-export type CLIType = 'claude' | 'cursor' | 'qwen' | 'gemini' | 'codex';
+export type CLIType = 'claude' | 'cursor' | 'qwen' | 'router' | 'gemini' | 'codex';

--- a/guides/claude-code-router.md
+++ b/guides/claude-code-router.md
@@ -1,0 +1,151 @@
+# Claude Code Router Setup
+
+This guide walks through using [claude-code-router](https://github.com/musistudio/claude-code-router) with Claudable to proxy
+[OpenRouter](https://openrouter.ai/) models such as **Qwen 3 Coder**. The router exposes an Anthropic-compatible Messages API,
+so Claudable can reuse its Claude tooling (terminal, MCP, file edits) without any additional plugins.
+
+> **Prerequisites**
+>
+> - OpenRouter account with API key (create one from the OpenRouter dashboard)
+> - Node.js ≥ 18 and Python ≥ 3.10 (already required for Claudable)
+> - A running Claudable API instance (`npm run dev` from the repo root)
+
+---
+
+## 1. Install the router CLI
+
+```bash
+npm install -g @musistudio/claude-code-router
+```
+
+Verify the installation:
+
+```bash
+ccr --version
+```
+
+---
+
+## 2. Configure OpenRouter as the upstream provider
+
+Create `~/.claude-code-router/config.json` (the CLI creates the folder on first
+run). The example below maps the router's default model to OpenRouter's
+`qwen/qwen3-coder` target and forwards your API key in the `x-api-key`
+header that OpenRouter expects:
+
+```json
+{
+  "servers": {
+    "default": {
+      "port": 3456
+    }
+  },
+  "providers": {
+    "openrouter": {
+      "baseURL": "https://openrouter.ai/api",
+      "apiKey": "${OPENROUTER_API_KEY}",
+      "defaultHeaders": {
+        "HTTP-Referer": "https://claudable.local"
+      }
+    }
+  },
+  "routers": {
+    "default": {
+      "defaultProvider": "openrouter",
+      "routes": {
+        "openrouter,qwen/qwen3-coder": {
+          "default": true
+        }
+      }
+    }
+  }
+}
+```
+
+You can keep the `${OPENROUTER_API_KEY}` placeholder and export the key in your
+shell before launching the router:
+
+```bash
+export OPENROUTER_API_KEY="sk-or-..."
+```
+
+---
+
+## 3. Launch the router
+
+```bash
+ccr start --router default
+```
+
+By default the router listens on port **3456**. You can change this with
+`--port` or by editing the config shown above.
+
+Leave the process running; Claudable will stream chat sessions to this HTTP
+server.
+
+---
+
+## 4. Connect Claudable to the router
+
+Claudable reads the following environment variables at startup:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `CLAUDE_CODE_ROUTER_URL` | Optional | Base URL to the running router (e.g. `http://127.0.0.1:3456`). If omitted, Claudable falls back to `http://127.0.0.1:${CLAUDE_CODE_ROUTER_PORT}` or the Codespaces forwarding URL. |
+| `CLAUDE_CODE_ROUTER_PORT` | Optional | Overrides the fallback port (default `3456`). Useful when the router runs on a different port but you do not want to hardcode the full URL. |
+| `CLAUDE_CODE_ROUTER_API_KEY` | Optional | API key forwarded to the router via `x-api-key` and `Authorization` headers. Set this if your router requires authentication. |
+| `CLAUDE_CODE_ROUTER_MODEL` | Optional | Overrides the default model mapping (`openrouter,qwen/qwen3-coder`). |
+
+Export the variables and restart the API process so it picks up the changes:
+
+```bash
+export CLAUDE_CODE_ROUTER_URL="http://127.0.0.1:3456"
+export CLAUDE_CODE_ROUTER_API_KEY="${OPENROUTER_API_KEY}"
+export CLAUDE_CODE_ROUTER_MODEL="openrouter,qwen/qwen3-coder"
+# restart the API (for example by re-running `npm run dev`)
+```
+
+---
+
+## 5. GitHub Codespaces quick start
+
+Codespaces run both the Claudable backend and the router inside the same
+container. In most situations you can rely on the default loopback URL, but the
+forwarding domain is handy when you want to hit the router from your local
+machine or share the endpoint with a teammate.
+
+```bash
+# Optional: expose the router through the public forwarding domain
+export CLAUDE_CODE_ROUTER_PORT=3456
+export CLAUDE_CODE_ROUTER_URL="https://${CLAUDE_CODE_ROUTER_PORT}-${CODESPACE_NAME}.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+
+# Ensure the Claudable backend can call the router directly inside the Codespace
+export CLAUDE_CODE_ROUTER_API_KEY="${OPENROUTER_API_KEY}"  # if needed
+```
+
+Then, in two terminals inside the Codespace:
+
+```bash
+# Terminal 1 – start the router
+OPENROUTER_API_KEY=sk-or-... ccr start --router default --port ${CLAUDE_CODE_ROUTER_PORT:-3456}
+
+# Terminal 2 – start Claudable (automatically picks up the env vars)
+npm run dev
+```
+
+When the web UI loads, open **Settings → AI Agents** and press **Refresh
+Status**. The **Claude Code Router** entry should report as installed, and you
+can now select it from the home page assistant dropdown.
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| Home page option stays greyed out | Confirm the router is reachable: `curl $CLAUDE_CODE_ROUTER_URL/health`. The API needs a `200` response. |
+| `Router request failed: ...` in the terminal | Check that the router process is running and that your OpenRouter API key has sufficient quota. |
+| Missing tool results or partial edits | The router streams Anthropic Messages events. Ensure you are running the latest `@musistudio/claude-code-router` release so tool invocations are forwarded correctly. |
+
+For additional router configuration options, refer to the
+[claude-code-router README](https://github.com/musistudio/claude-code-router#readme).


### PR DESCRIPTION
## Summary
- add a Claude Code Router CLI adapter that proxies Anthropic-style streaming over HTTP, reuses project sessions, and executes local tools for router-issued commands
- register the router across backend enums and availability checks while keeping image uploads disabled like Qwen, and document the setup in a dedicated guide
- surface the router alongside other assistants in the web UI with default model mappings, install/test actions, and safeguards that disable image inputs

## Testing
- python -m compileall apps/api/app/services/cli/adapters/claude_code_router.py
- CI=1 npm run build *(fails: missing root build script)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d539cdf88332a3fa3bf2cf6236fd